### PR TITLE
Env int load report fix

### DIFF
--- a/lib/measures/envelope_and_internal_load_breakdown/measure.rb
+++ b/lib/measures/envelope_and_internal_load_breakdown/measure.rb
@@ -65,14 +65,14 @@ class EnvelopeAndInternalLoadBreakdown < OpenStudio::Ruleset::ReportingUserScrip
     result = []
 
     # instead of hand populating, any methods with 'section' in the name will be added in the order they appear
-    all_setions = OsLib_ReportingHeatGainLoss.methods(false)
-    all_setions.each do |section|
+    all_sections = OsLib_ReportingHeatGainLoss.methods(false)
+    method_hash = {}
+    all_sections.each do |section|
       next if !section.to_s.include? 'section'
-      result << section.to_s
+      method_hash[section.to_s] = OsLib_ReportingHeatGainLoss.method(section).source_location.last
     end
-
-    # old method is passing in wrong order and breaking function of measure. Hard coding the desired order below
-    result = ['heat_gains_section','heat_gains_summary_section','heat_losses_section','heat_loss_summary_section']
+    # sort methods by location in file (this was not necessary when using Ruby 2.2.4)
+    result = method_hash.sort_by {|_key, value| value}.to_h.keys
 
     result
   end

--- a/lib/measures/envelope_and_internal_load_breakdown/measure.rb
+++ b/lib/measures/envelope_and_internal_load_breakdown/measure.rb
@@ -71,6 +71,9 @@ class EnvelopeAndInternalLoadBreakdown < OpenStudio::Ruleset::ReportingUserScrip
       result << section.to_s
     end
 
+    # old method is passing in wrong order and breaking function of measure. Hard coding the desired order below
+    result = ['heat_gains_section','heat_gains_summary_section','heat_losses_section','heat_loss_summary_section']
+
     result
   end
 

--- a/lib/measures/envelope_and_internal_load_breakdown/measure.rb
+++ b/lib/measures/envelope_and_internal_load_breakdown/measure.rb
@@ -72,7 +72,7 @@ class EnvelopeAndInternalLoadBreakdown < OpenStudio::Ruleset::ReportingUserScrip
       method_hash[section.to_s] = OsLib_ReportingHeatGainLoss.method(section).source_location.last
     end
     # sort methods by location in file (this was not necessary when using Ruby 2.2.4)
-    result = method_hash.sort_by {|_key, value| value}.to_h.keys
+    result = method_hash.sort_by { |_key, value| value }.to_h.keys
 
     result
   end

--- a/lib/measures/envelope_and_internal_load_breakdown/measure.xml
+++ b/lib/measures/envelope_and_internal_load_breakdown/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>envelope_and_internal_load_breakdown</name>
   <uid>8f0e1fbb-8bc6-46e5-b6e4-db59177e2c02</uid>
-  <version_id>dc19cbc4-8b3c-4676-9c67-79fc751ba6c0</version_id>
-  <version_modified>20200509T041912Z</version_modified>
+  <version_id>7ba824c2-f08f-4c5c-bdd6-2aa1965bd3e6</version_id>
+  <version_modified>20200522T215252Z</version_modified>
   <xml_checksum>69BA4D91</xml_checksum>
   <class_name>EnvelopeAndInternalLoadBreakdown</class_name>
   <display_name>Envelope and Internal Load Breakdown</display_name>
@@ -113,12 +113,6 @@
       <checksum>E0468DD6</checksum>
     </file>
     <file>
-      <filename>EnvelopeAndInternalLoadBreakdown_Test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>A8844C42</checksum>
-    </file>
-    <file>
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
@@ -131,6 +125,12 @@
       <checksum>BDF70EAA</checksum>
     </file>
     <file>
+      <filename>EnvelopeAndInternalLoadBreakdown_Test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>FFA0DD94</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.0.0</identifier>
@@ -139,7 +139,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>1D8E4DB0</checksum>
+      <checksum>EE6FB1AD</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/envelope_and_internal_load_breakdown/tests/EnvelopeAndInternalLoadBreakdown_Test.rb
+++ b/lib/measures/envelope_and_internal_load_breakdown/tests/EnvelopeAndInternalLoadBreakdown_Test.rb
@@ -167,7 +167,7 @@ class EnvelopeAndInternalLoadBreakdown_Test < MiniTest::Unit::TestCase
 
   # assert that no section errors were thrown
   def section_errors(runner)
-    test_string = 'Error prevented QAQC check from running'
+    test_string = 'section failed and was skipped because'
 
     if is_openstudio_2?
       section_errors = []

--- a/lib/measures/envelope_and_internal_load_breakdown/tests/EnvelopeAndInternalLoadBreakdown_Test.rb
+++ b/lib/measures/envelope_and_internal_load_breakdown/tests/EnvelopeAndInternalLoadBreakdown_Test.rb
@@ -167,7 +167,7 @@ class EnvelopeAndInternalLoadBreakdown_Test < MiniTest::Unit::TestCase
 
   # assert that no section errors were thrown
   def section_errors(runner)
-    test_string = 'section failed and was skipped because'
+    test_string = 'section returned false and was skipped'
 
     if is_openstudio_2?
       section_errors = []

--- a/lib/measures/example_report/measure.rb
+++ b/lib/measures/example_report/measure.rb
@@ -72,7 +72,7 @@ class ExampleReport < OpenStudio::Measure::ReportingMeasure
       method_hash[section.to_s] = OsLib_Reporting_example.method(section).source_location.last
     end
     # sort methods by location in file (this was not necessary when using Ruby 2.2.4)
-    result = method_hash.sort_by {|_key, value| value}.to_h.keys
+    result = method_hash.sort_by { |_key, value| value }.to_h.keys
 
     result
   end

--- a/lib/measures/example_report/measure.rb
+++ b/lib/measures/example_report/measure.rb
@@ -65,11 +65,14 @@ class ExampleReport < OpenStudio::Measure::ReportingMeasure
     result = []
 
     # instead of hand populating, any methods with 'section' in the name will be added in the order they appear
-    all_setions = OsLib_Reporting_example.methods(false)
-    all_setions.each do |section|
+    all_sections = OsLib_Reporting_example.methods(false)
+    method_hash = {}
+    all_sections.each do |section|
       next if !section.to_s.include? 'section'
-      result << section.to_s
+      method_hash[section.to_s] = OsLib_Reporting_example.method(section).source_location.last
     end
+    # sort methods by location in file (this was not necessary when using Ruby 2.2.4)
+    result = method_hash.sort_by {|_key, value| value}.to_h.keys
 
     result
   end

--- a/lib/measures/example_report/measure.xml
+++ b/lib/measures/example_report/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>example_report</name>
   <uid>174a6f71-3e8c-4f99-9e7a-b64f2e7535d4</uid>
-  <version_id>a274e765-411c-4d8c-b68c-93ca1cc29a1c</version_id>
-  <version_modified>20200509T041907Z</version_modified>
+  <version_id>51aafe85-207e-4ec1-a44f-dd14a0dc0d0f</version_id>
+  <version_modified>20200522T215243Z</version_modified>
   <xml_checksum>557BF06F</xml_checksum>
   <class_name>ExampleReport</class_name>
   <display_name>Example Report</display_name>
@@ -153,12 +153,6 @@
       <checksum>E0468DD6</checksum>
     </file>
     <file>
-      <filename>ExampleReport_Test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>AFC7D248</checksum>
-    </file>
-    <file>
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
@@ -171,6 +165,12 @@
       <checksum>708516C5</checksum>
     </file>
     <file>
+      <filename>ExampleReport_Test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DF6EDC31</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.0.0</identifier>
@@ -179,7 +179,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>4107DCF6</checksum>
+      <checksum>BE43D3F6</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/example_report/tests/ExampleReport_Test.rb
+++ b/lib/measures/example_report/tests/ExampleReport_Test.rb
@@ -172,7 +172,7 @@ class ExampleReport_Test < Minitest::Test
 
   # assert that no section errors were thrown
   def section_errors(runner)
-    test_string = 'Error prevented QAQC check from running'
+    test_string = 'section returned false and was skipped'
 
     if is_openstudio_2?
       section_errors = []


### PR DESCRIPTION
Fix to env and int load report caused by order of how methods are read in from resource file. Related updates to example_report measure.