### PR TITLE
Update measure.rb

### DIFF
--- a/lib/measures/ChangeBuildingLocation/measure.rb
+++ b/lib/measures/ChangeBuildingLocation/measure.rb
@@ -122,6 +122,8 @@ class ChangeBuildingLocation < OpenStudio::Measure::ModelMeasure
             args[arg] = new_val.to_f
           elsif arg == 'zipcode'
             args[arg] = new_val.to_i
+          elsif arg == 'set_year'
+            args[arg] = new_val.to_i
           else
             args[arg] = new_val
           end


### PR DESCRIPTION
Supporting use of set_year upstream measures as an integer instead of a string. I plan better support non string upstream arguments in extension gem at a later date. https://github.com/NREL/openstudio-extension-gem/blob/develop/lib/openstudio/extension/core/os_lib_helper_methods.rb#L253