### PR TITLE
just kicking it so it has version ID I can push to BCL

### DIFF
--- a/lib/measures/air_wall_zone_mixing/measure.xml
+++ b/lib/measures/air_wall_zone_mixing/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>air_wall_zone_mixing</name>
   <uid>fd04f73e-a530-4144-9e1e-c1878b1394bc</uid>
-  <version_id>65c3f123-bb44-4515-bfc8-5844b3b1f8a1</version_id>
-  <version_modified>20200401T050057Z</version_modified>
+  <version_id>6a4263c6-3899-44e8-9b9e-19b5be357d51</version_id>
+  <version_modified>20210331T231502Z</version_modified>
   <xml_checksum>772B7164</xml_checksum>
   <class_name>AirWallZoneMixing</class_name>
   <display_name>Air Wall Zone Mixing</display_name>


### PR DESCRIPTION
Version on BCL is from June 2020 and not December but seems to have this version ID so I couldn't upload without this change.

https://unmethours.com/question/53647/air-wall-zone-mixing-not-compatible-with-new-version-of-openstudio/