### PR TITLE
Replace OsLib_HelperMethod calls with new runner methods

### DIFF
--- a/lib/measures/ChangeBuildingLocation/measure.rb
+++ b/lib/measures/ChangeBuildingLocation/measure.rb
@@ -74,14 +74,16 @@ class ChangeBuildingLocation < OpenStudio::Measure::ModelMeasure
     super(model, runner, user_arguments)
 
     # assign the user inputs to variables
-    args = OsLib_HelperMethods.createRunVariables(runner, model, user_arguments, arguments(model))
+    args = runner.getArgumentValues(arguments(model), user_arguments)
+    args = Hash[args.collect{ |k, v| [k.to_s, v] }]
     if !args then return false end
 
     # lookup and replace argument values from upstream measures
     if args['use_upstream_args'] == true
       args.each do |arg, value|
         next if arg == 'use_upstream_args' # this argument should not be changed
-        value_from_osw = OsLib_HelperMethods.check_upstream_measure_for_arg(runner, arg)
+        value_from_osw = runner.getPastStepValuesForName(arg)
+        value_from_osw = value_from_osw.collect{ |k, v| Hash[:measure_name => k, :value => v] }.first if !value_from_osw.empty?
         if !value_from_osw.empty?
           runner.registerInfo("Replacing argument named #{arg} from current measure with a value of #{value_from_osw[:value]} from #{value_from_osw[:measure_name]}.")
           new_val = value_from_osw[:value]

--- a/lib/measures/add_rooftop_pv/measure.rb
+++ b/lib/measures/add_rooftop_pv/measure.rb
@@ -68,7 +68,8 @@ class AddRooftopPV < OpenStudio::Measure::ModelMeasure
     end
 
     # assign the user inputs to variables
-    args = OsLib_HelperMethods.createRunVariables(runner, model, user_arguments, arguments(model))
+    args = runner.getArgumentValues(arguments(model), user_arguments)
+    args = Hash[args.collect{ |k, v| [k.to_s, v] }]
     if !args then return false end
 
     # check expected values of double arguments

--- a/lib/measures/example_report/measure.rb
+++ b/lib/measures/example_report/measure.rb
@@ -88,7 +88,8 @@ class ExampleReport < OpenStudio::Measure::ReportingMeasure
     web_asset_path = setup[:web_asset_path]
 
     # assign the user inputs to variables
-    args = OsLib_HelperMethods.createRunVariables(runner, model, user_arguments, arguments)
+    args = runner.getArgumentValues(arguments, user_arguments)
+    args = Hash[args.collect{ |k, v| [k.to_s, v] }]
     unless args
       return false
     end

--- a/lib/measures/generic_qaqc/measure.rb
+++ b/lib/measures/generic_qaqc/measure.rb
@@ -169,7 +169,8 @@ class GenericQAQC < OpenStudio::Measure::ReportingMeasure
     result = OpenStudio::IdfObjectVector.new
 
     # assign the user inputs to variables
-    args = OsLib_HelperMethods.createRunVariables(runner, @model, user_arguments, arguments)
+    args = runner.getArgumentValues(arguments, user_arguments)
+    args = Hash[args.collect{ |k, v| [k.to_s, v] }]
     unless args
       return false
     end
@@ -231,7 +232,8 @@ class GenericQAQC < OpenStudio::Measure::ReportingMeasure
     climateZones.setClimateZone('ASHRAE', cz)
 
     # assign the user inputs to variables
-    args = OsLib_HelperMethods.createRunVariables(runner, @model, user_arguments, arguments)
+    args = runner.getArgumentValues(arguments, user_arguments)
+    args = Hash[args.collect{ |k, v| [k.to_s, v] }]
     unless args
       return false
     end
@@ -246,7 +248,8 @@ class GenericQAQC < OpenStudio::Measure::ReportingMeasure
     if args['use_upstream_args'] == true
       args.each do |arg, value|
         next if arg == 'use_upstream_args' # this argument should not be changed
-        value_from_osw = OsLib_HelperMethods.check_upstream_measure_for_arg(runner, arg)
+        value_from_osw = runner.getPastStepValuesForName(arg)
+        value_from_osw = value_from_osw.collect{ |k, v| Hash[:measure_name => k, :value => v] }.first if !value_from_osw.empty?
         if !value_from_osw.empty?
           runner.registerInfo("Replacing argument named #{arg} from current measure with a value of #{value_from_osw[:value]} from #{value_from_osw[:measure_name]}.")
           new_val = value_from_osw[:value]

--- a/lib/measures/get_site_from_building_component_library/measure.rb
+++ b/lib/measures/get_site_from_building_component_library/measure.rb
@@ -56,14 +56,16 @@ class GetSiteFromBuildingComponentLibrary < OpenStudio::Measure::ModelMeasure
     super(model, runner, user_arguments)
 
     # assign the user inputs to variables
-    args = OsLib_HelperMethods.createRunVariables(runner, model, user_arguments, arguments(model))
+    args = runner.getArgumentValues(arguments(model), user_arguments)
+    args = Hash[args.collect{ |k, v| [k.to_s, v] }]
     if !args then return false end
 
     # lookup and replace argument values from upstream measures
     if args['use_upstream_args'] == true
       args.each do |arg, value|
         next if arg == 'use_upstream_args' # this argument should not be changed
-        value_from_osw = OsLib_HelperMethods.check_upstream_measure_for_arg(runner, arg)
+        value_from_osw = runner.getPastStepValuesForName(arg)
+        value_from_osw = value_from_osw.collect{ |k, v| Hash[:measure_name => k, :value => v] }.first if !value_from_osw.empty?
         if !value_from_osw.empty?
           runner.registerInfo("Replacing argument named #{arg} from current measure with a value of #{value_from_osw[:value]} from #{value_from_osw[:measure_name]}.")
           new_val = value_from_osw[:value]

--- a/lib/measures/openstudio_results/measure.rb
+++ b/lib/measures/openstudio_results/measure.rb
@@ -213,7 +213,8 @@ class OpenStudioResults < OpenStudio::Measure::ReportingMeasure
     web_asset_path = setup[:web_asset_path]
 
     # assign the user inputs to variables
-    args = OsLib_HelperMethods.createRunVariables(runner, model, user_arguments, arguments)
+    args = runner.getArgumentValues(arguments, user_arguments)
+    args = Hash[args.collect{ |k, v| [k.to_s, v] }]
     unless args
       return false
     end

--- a/lib/measures/tariff_selection_block/measure.rb
+++ b/lib/measures/tariff_selection_block/measure.rb
@@ -104,7 +104,8 @@ class TariffSelectionBlock < OpenStudio::Measure::EnergyPlusMeasure
     super(workspace, runner, user_arguments)
 
     # assign the user inputs to variables
-    args = OsLib_HelperMethods.createRunVariables(runner, workspace, user_arguments, arguments(workspace))
+    args = runner.getArgumentValues(arguments(workspace), user_arguments)
+    args = Hash[args.collect{ |k, v| [k.to_s, v] }]
     if !args then return false end
 
     # make arrays out of comma separated string inputs

--- a/lib/measures/tariff_selection_flat/measure.rb
+++ b/lib/measures/tariff_selection_flat/measure.rb
@@ -108,7 +108,9 @@ class TariffSelectionFlat < OpenStudio::Measure::EnergyPlusMeasure
     super(workspace, runner, user_arguments)
 
     # assign the user inputs to variables
-    args = OsLib_HelperMethods.createRunVariables(runner, workspace, user_arguments, arguments(workspace))
+    args = runner.getArgumentValues(arguments(workspace), user_arguments)
+    args = Hash[args.collect{ |k, v| [k.to_s, v] }]
+    
     if !args then return false end
 
     # reporting initial condition of model

--- a/lib/measures/tariff_selection_generic/measure.rb
+++ b/lib/measures/tariff_selection_generic/measure.rb
@@ -98,7 +98,8 @@ class TariffSelectionGeneric < OpenStudio::Measure::EnergyPlusMeasure
   def run(workspace, runner, user_arguments)
     super(workspace, runner, user_arguments)
 
-    args = OsLib_HelperMethods.createRunVariables(runner, workspace, user_arguments, arguments(workspace))
+    args = runner.getArgumentValues(arguments(workspace), user_arguments)
+    args = Hash[args.collect{ |k, v| [k.to_s, v] }]
     if !args then return false end
 
     # reporting initial condition of model


### PR DESCRIPTION
Replacements:
* `OsLib_HelperMethods.createRunVariables` -> `runner.getArgumentValues`
* `OsLib_HelperMethods.check_upstream_measure_for_arg` -> `runner.getPastStepValuesForName`
* `OsLib_HelperMethods.checkDoubleAndIntegerArguments` -> `arg.setMinValue` and `arg.setMaxValue` (and `runner.validateUserArguments`)