### PR TITLE
AddRooftopPV: name objects + set explicit critical defaults + write ratedElectricPowerOutput

### DIFF
--- a/lib/measures/add_rooftop_pv/measure.xml
+++ b/lib/measures/add_rooftop_pv/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>add_rooftop_pv</name>
   <uid>34550614-0c87-44db-9252-0ca0915b1e64</uid>
-  <version_id>0d2f5512-be0c-4af5-a651-139c86a3adf0</version_id>
-  <version_modified>2024-11-16T23:54:15Z</version_modified>
+  <version_id>9d89354d-e768-49c9-8469-feec117ef065</version_id>
+  <version_modified>2025-03-03T09:52:15Z</version_modified>
   <xml_checksum>178163B6</xml_checksum>
   <class_name>AddRooftopPV</class_name>
   <display_name>Add Rooftop PV</display_name>
@@ -114,7 +114,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>9AA2D6EE</checksum>
+      <checksum>47313383</checksum>
     </file>
     <file>
       <filename>add_rooftop_pv_test.rb</filename>


### PR DESCRIPTION
AddRooftopPV. Not producing any difference in simulation results, just cosmetic / style things and a reporting-oriented change.

* Name objects (makes debugging much easier)
* Set explicit critical defaults, for the ELCD in particular
* write GeneratorPhotovoltaic's ratedElectricPowerOutput so that eplutbl.html reports it as non zero in the LEED table `L-1. Renewable Energy Source Summary`

![image](https://github.com/user-attachments/assets/e5e470c9-04f4-4dbd-9101-fe0c3c5d52ac)
