### PR TITLE
ZoneReport fixes for 3.9.0

### DIFF
--- a/lib/measures/ZoneReport/measure.rb
+++ b/lib/measures/ZoneReport/measure.rb
@@ -340,10 +340,10 @@ class ZoneReport < OpenStudio::Measure::ReportingMeasure
       vals[:vs] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorEquipment:Electricity:Zone:#{zoneMetrics[:name]}", 'Electricity Annual Value', 'GJ', 'kWh').round(2)
 
       vals[:vt] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Natural Gas', "InteriorEquipment:NaturalGas:Zone:#{zoneMetrics[:name]}", 'Natural Gas Maximum Value', 'W', 'kBtu/hr').round(2)
-      vals[:vu] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Natural Gas', "InteriorEquipment:NaturalGas:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
+      vals[:vu] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Natural Gas', "InteriorEquipment:NaturalGas:Zone:#{zoneMetrics[:name]}", 'Timestamp of Maximum {TIMESTAMP}', '', 's')
 
       vals[:vv] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorLights:Electricity:Zone:#{zoneMetrics[:name]}", 'Electricity Maximum Value', 'W', 'kW').round(2)
-      vals[:vw] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorLights:Electricity:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
+      vals[:vw] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorLights:Electricity:Zone:#{zoneMetrics[:name]}", 'Timestamp of Maximum {TIMESTAMP}', '', 's')
 
       # calculate lighting values based on EnergyMeters, which has data by zone
       # instead of Lighting Summary, which has data by space
@@ -357,19 +357,19 @@ class ZoneReport < OpenStudio::Measure::ReportingMeasure
       # X unused
 
       vals[:vy] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorEquipment:Electricity:Zone:#{zoneMetrics[:name]}", 'Electricity Maximum Value', 'W', 'kW').round(2)
-      vals[:vz] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorEquipment:Electricity:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
+      vals[:vz] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorEquipment:Electricity:Zone:#{zoneMetrics[:name]}", 'Timestamp of Maximum {TIMESTAMP}', '', 's')
 
-      vals[:vaa] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "InteriorEquipment:DistrictHeatingWater:Zone:#{zoneMetrics[:name]}", 'Annual Value', 'GJ', 'kBtu').round(2)
-      vals[:vab] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "InteriorEquipment:DistrictHeatingWater:Zone:#{zoneMetrics[:name]}", 'Maximum Value', 'W', 'kBtu/hr').round(2)
-      vals[:vac] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "InteriorEquipment:DistrictHeatingWater:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
+      # vals[:vaa] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "InteriorEquipment:DistrictHeatingWater:Zone:#{zoneMetrics[:name]}", 'Annual Value', 'GJ', 'kBtu').round(2)
+      # vals[:vab] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "InteriorEquipment:DistrictHeatingWater:Zone:#{zoneMetrics[:name]}", 'Maximum Value', 'W', 'kBtu/hr').round(2)
+      # vals[:vac] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "InteriorEquipment:DistrictHeatingWater:Zone:#{zoneMetrics[:name]}", 'Timestamp of Maximum {TIMESTAMP}', '', 's')
 
-      vals[:vad] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Heating:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Annual Value', 'GJ', 'kBtu').round(2)
-      vals[:vae] = (getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Heating:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Maximum Value', 'W', 'kBtu/hr') / zoneMetrics[:area]).round(2)
-      vals[:vaf] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Heating:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
+      # vals[:vad] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Heating:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Annual Value', 'GJ', 'kBtu').round(2)
+      # vals[:vae] = (getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Heating:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Maximum Value', 'W', 'kBtu/hr') / zoneMetrics[:area]).round(2)
+      # vals[:vaf] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Heating:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Timestamp of Maximum {TIMESTAMP}', '', 's')
 
-      vals[:vag] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Cooling:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Annual Value', 'GJ', 'kBtu').round(2)
-      vals[:vah] = (getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Cooling:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Maximum Value', 'W', 'kBtu/hr') / zoneMetrics[:area]).round(2)
-      vals[:vai] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Cooling:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
+      # vals[:vag] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Cooling:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Annual Value', 'GJ', 'kBtu').round(2)
+      # vals[:vah] = (getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Cooling:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Maximum Value', 'W', 'kBtu/hr') / zoneMetrics[:area]).round(2)
+      # vals[:vai] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Cooling:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Timestamp of Maximum {TIMESTAMP}', '', 's')
 
       vals[:vaj] = zoneHeatComponentCalc('People', zoneMetrics)
       vals[:vak] = zoneHeatComponentCalc('Lights', zoneMetrics)

--- a/lib/measures/ZoneReport/measure.rb
+++ b/lib/measures/ZoneReport/measure.rb
@@ -308,8 +308,8 @@ class ZoneReport < OpenStudio::Measure::ReportingMeasure
 
       #vals[:va] = getDetailsData('Input Verification and Results Summary', 'Entire Facility', 'Zone Summary', "#{zoneMetrics[:name].upcase}", 'Lighting[W/m2]', 'W/m2', 'W/ft^2').round(2)
       #vals[:va] = getDetailsData('Initialization Summary', 'Entire Facility', 'Zone Internal Gains Nominal', "#{zoneMetrics[:name].upcase}", 'Interior Lighting', 'W/m2', 'W/ft^2').round(2)
-      vals[:va] = getDetailsData('LightingSummary', 'Entire Facility', 'Interior Lighting', "#{zoneMetrics[:name]}%", 'Lighting Power Density', 'W/m2', 'W/ft^2').round(2)
-      vals[:vb] = getDetailsData('LightingSummary', 'Entire Facility', 'Interior Lighting', "#{zoneMetrics[:name]}%", 'Full Load Hours/Week', 'hr', 'hr').round(2)
+      # vals[:va] = getDetailsData('LightingSummary', 'Entire Facility', 'Interior Lighting', "#{zoneMetrics[:name]}%", 'Lighting Power Density', 'W/m2', 'W/ft^2').round(2)
+      # vals[:vb] = getDetailsData('LightingSummary', 'Entire Facility', 'Interior Lighting', "#{zoneMetrics[:name]}%", 'Full Load Hours/Week', 'hr', 'hr').round(2)
 
       vals[:vc] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorLights:Electricity:Zone:#{zoneMetrics[:name]}", 'Electricity Annual Value', 'GJ', 'kWh').round(2)
 
@@ -344,6 +344,15 @@ class ZoneReport < OpenStudio::Measure::ReportingMeasure
 
       vals[:vv] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorLights:Electricity:Zone:#{zoneMetrics[:name]}", 'Electricity Maximum Value', 'W', 'kW').round(2)
       vals[:vw] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorLights:Electricity:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
+
+      # calculate lighting values based on EnergyMeters, which has data by zone
+      # instead of Lighting Summary, which has data by space
+
+      # W/ft2
+      vals[:va] = (vals[:vv] * 1000 / zoneMetrics[:area]).round(2)
+
+      # kWh / kW = full load hours
+      vals[:vb] = (vals[:vc] / vals[:vv]).round(2)
 
       # X unused
 

--- a/lib/measures/ZoneReport/measure.rb
+++ b/lib/measures/ZoneReport/measure.rb
@@ -320,18 +320,18 @@ class ZoneReport < OpenStudio::Measure::ReportingMeasure
       vals[:vf] = getDetailsData('InputVerificationandResultsSummary', 'Entire Facility', 'Zone Summary', zoneMetrics[:name], 'Conditioned (Y/N)', '', 's')
       if vals[:vf] == '' then vals[:vf] = 'No' end
 
-      vals[:vg] = getDetailsData('HVACSizingSummary', 'Entire Facility', 'Zone Heating', zoneMetrics[:name], 'User Design Load', 'W', 'kBtu/hr').round(2)
-      vals[:vh] = getDetailsData('HVACSizingSummary', 'Entire Facility', 'Zone Heating', zoneMetrics[:name], 'User Design Air Flow', 'm3/s', 'ft^3/s').round(2)
-      vals[:vi] = getDetailsData('HVACSizingSummary', 'Entire Facility', 'Zone Cooling', zoneMetrics[:name], 'User Design Load', 'W', 'kBtu/hr').round(2)
-      vals[:vj] = getDetailsData('HVACSizingSummary', 'Entire Facility', 'Zone Cooling', zoneMetrics[:name], 'User Design Air Flow', 'm3/s', 'ft^3/s').round(2)
+      vals[:vg] = getDetailsData('HVACSizingSummary', 'Entire Facility', 'Zone Sensible Heating', zoneMetrics[:name], 'User Design Load', 'W', 'kBtu/hr').round(2)
+      vals[:vh] = getDetailsData('HVACSizingSummary', 'Entire Facility', 'Zone Sensible Heating', zoneMetrics[:name], 'User Design Air Flow', 'm3/s', 'ft^3/s').round(2)
+      vals[:vi] = getDetailsData('HVACSizingSummary', 'Entire Facility', 'Zone Sensible Cooling', zoneMetrics[:name], 'User Design Load', 'W', 'kBtu/hr').round(2)
+      vals[:vj] = getDetailsData('HVACSizingSummary', 'Entire Facility', 'Zone Sensible Cooling', zoneMetrics[:name], 'User Design Air Flow', 'm3/s', 'ft^3/s').round(2)
 
       vals[:vk] = getDetailsData('OutdoorAirSummary', 'Entire Facility', 'Average Outdoor Air During Occupied Hours', zoneMetrics[:name], 'Mechanical Ventilation', 'ach', 'ach').round(2)
       vals[:vl] = getDetailsData('OutdoorAirSummary', 'Entire Facility', 'Average Outdoor Air During Occupied Hours', zoneMetrics[:name], 'Infiltration', 'ach', 'ach').round(2)
 
       vals[:vm] = getDetailsData('InputVerificationandResultsSummary', 'Entire Facility', 'Zone Summary', zoneMetrics[:name], 'People', 'm2 per person', 'ft^2/person').round(2)
 
-      vals[:vn] = getDetailsData('HVACSizingSummary', 'Entire Facility', 'Zone Cooling', zoneMetrics[:name], 'Date/Time Of Peak', '', 's')
-      vals[:vo] = getDetailsData('HVACSizingSummary', 'Entire Facility', 'Zone Heating', zoneMetrics[:name], 'Date/Time Of Peak', '', 's')
+      vals[:vn] = getDetailsData('HVACSizingSummary', 'Entire Facility', 'Zone Sensible Cooling', zoneMetrics[:name], 'Date/Time Of Peak {TIMESTAMP}', '', 's')
+      vals[:vo] = getDetailsData('HVACSizingSummary', 'Entire Facility', 'Zone Sensible Heating', zoneMetrics[:name], 'Date/Time Of Peak {TIMESTAMP}', '', 's')
 
       vals[:vp] = getDetailsData('SystemSummary', 'Entire Facility', 'Time Setpoint Not Met', zoneMetrics[:name], 'During Heating', 'hr', 'hr')
       vals[:vq] = getDetailsData('SystemSummary', 'Entire Facility', 'Time Setpoint Not Met', zoneMetrics[:name], 'During Cooling', 'hr', 'hr')

--- a/lib/measures/ZoneReport/measure.rb
+++ b/lib/measures/ZoneReport/measure.rb
@@ -387,7 +387,7 @@ class ZoneReport < OpenStudio::Measure::ReportingMeasure
       vals[:vbf] = zoneHeatComponentCalc('Fenestration Conduction', zoneMetrics)
       vals[:vbg] = zoneHeatComponentCalc('Fenestration Solar', zoneMetrics)
 
-      vals[:vbh] = getDetailsData('ZoneComponentLoadSummary', (zoneMetrics[:name]).to_s, 'Heating Peak Conditions', 'Time of Peak Load', 'Value', '', 's')
+      vals[:vbh] = getDetailsData('Zone Component Load Summary', (zoneMetrics[:name]).to_s, 'Heating Peak Conditions', 'Time of Peak Load', 'Value', '', 's')
 
       vals[:vbi] = zoneCoolComponentCalc('People', zoneMetrics)
       vals[:vbj] = zoneCoolComponentCalc('Lights', zoneMetrics)
@@ -414,7 +414,7 @@ class ZoneReport < OpenStudio::Measure::ReportingMeasure
       vals[:vce] = zoneCoolComponentCalc('Fenestration Conduction', zoneMetrics)
       vals[:vcf] = zoneCoolComponentCalc('Fenestration Solar', zoneMetrics)
 
-      vals[:vcg] = getDetailsData('ZoneComponentLoadSummary', (zoneMetrics[:name]).to_s, 'Cooling Peak Conditions', 'Time of Peak Load', 'Value', '', 's')
+      vals[:vcg] = getDetailsData('Zone Component Load Summary', (zoneMetrics[:name]).to_s, 'Cooling Peak Conditions', 'Time of Peak Load', 'Value', '', 's')
 
       # vals = loadTestVals( vals )
 
@@ -482,11 +482,11 @@ class ZoneReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def zoneHeatComponentCalc(component, zoneMetrics)
-    (getDetailsData('ZoneComponentLoadSummary', (zoneMetrics[:name]).to_s, 'Estimated Heating Peak Load Components', component, 'Total', 'W', 'Btu/hr') / zoneMetrics[:area]).round(2)
+    (getDetailsData('Zone Component Load Summary', (zoneMetrics[:name]).to_s, 'Estimated Heating Peak Load Components', component, 'Total', 'W', 'Btu/hr') / zoneMetrics[:area]).round(2)
   end
 
   def zoneCoolComponentCalc(component, zoneMetrics)
-    (getDetailsData('ZoneComponentLoadSummary', (zoneMetrics[:name]).to_s, 'Estimated Cooling Peak Load Components', component, 'Total', 'W', 'Btu/hr') / zoneMetrics[:area]).round(2)
+    (getDetailsData('Zone Component Load Summary', (zoneMetrics[:name]).to_s, 'Estimated Cooling Peak Load Components', component, 'Total', 'W', 'Btu/hr') / zoneMetrics[:area]).round(2)
   end
 
   def stacked_bars(zoneMetrics)
@@ -623,7 +623,7 @@ end
   # and final_units should be open studio style (m^2, m^3, ...)
   # If the data is not found or cannot be converted a warning is registered and "" or 0.0 is returned.
   def getDetailsData(report, forstring, table, row, column, units, final_units)
-    if report == 'ZoneComponentLoadSummary'
+    if report == 'Zone Component Load Summary'
       forstring.upcase!
     end
 
@@ -645,7 +645,7 @@ end
 
     else
       r = query_results.get
-      if report == 'ZoneComponentLoadSummary'
+      if report == 'Zone Component Load Summary'
         @testData["#{@currentZoneName}_#{table}_#{row}"] = r
       end
 

--- a/lib/measures/ZoneReport/measure.rb
+++ b/lib/measures/ZoneReport/measure.rb
@@ -306,6 +306,8 @@ class ZoneReport < OpenStudio::Measure::ReportingMeasure
 
       vals = {}
 
+      #vals[:va] = getDetailsData('Input Verification and Results Summary', 'Entire Facility', 'Zone Summary', "#{zoneMetrics[:name].upcase}", 'Lighting[W/m2]', 'W/m2', 'W/ft^2').round(2)
+      #vals[:va] = getDetailsData('Initialization Summary', 'Entire Facility', 'Zone Internal Gains Nominal', "#{zoneMetrics[:name].upcase}", 'Interior Lighting', 'W/m2', 'W/ft^2').round(2)
       vals[:va] = getDetailsData('LightingSummary', 'Entire Facility', 'Interior Lighting', "#{zoneMetrics[:name]}%", 'Lighting Power Density', 'W/m2', 'W/ft^2').round(2)
       vals[:vb] = getDetailsData('LightingSummary', 'Entire Facility', 'Interior Lighting', "#{zoneMetrics[:name]}%", 'Full Load Hours/Week', 'hr', 'hr').round(2)
 
@@ -637,7 +639,8 @@ end
 
     if query_results.empty?
 
-      @runner.registerWarning("Could not get data for #{report} #{forstring} #{table} #{row} #{column}.")
+      # todo - is there any valid reason data might not be found? If not then make error isntead of warning
+      @runner.registerWarning("Could not get data for report:#{report} For:#{forstring} table:#{table} row:#{row} column:#{column}.")
       return final_units == 's' ? '' : 0.0
 
     else
@@ -652,7 +655,7 @@ end
         converted = OpenStudio.convert(r.to_f, eplus_to_openstudio(units), final_units)
         if converted.empty?
           @runner.registerError("Could not convert #{r} from #{units} to #{final_units}")
-          return 0.0
+          return false
         else
           return converted.get.round(2)
         end
@@ -671,7 +674,7 @@ end
 
     if query_results.empty?
       @runner.registerError("Could not get data for requested Column #{colName}.")
-      return []
+      return false
     else
       return query_results
     end

--- a/lib/measures/ZoneReport/measure.rb
+++ b/lib/measures/ZoneReport/measure.rb
@@ -336,31 +336,31 @@ class ZoneReport < OpenStudio::Measure::ReportingMeasure
       vals[:vp] = getDetailsData('SystemSummary', 'Entire Facility', 'Time Setpoint Not Met', zoneMetrics[:name], 'During Heating', 'hr', 'hr')
       vals[:vq] = getDetailsData('SystemSummary', 'Entire Facility', 'Time Setpoint Not Met', zoneMetrics[:name], 'During Cooling', 'hr', 'hr')
 
-      vals[:vr] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Gas', "InteriorEquipment:Gas:Zone:#{zoneMetrics[:name]}", 'Electricity Annual Value', 'GJ', 'Therm').round(2)
+      vals[:vr] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Natural Gas', "InteriorEquipment:NaturalGas:Zone:#{zoneMetrics[:name]}", 'Natural Gas Annual Value', 'GJ', 'Therm').round(2)
       vals[:vs] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorEquipment:Electricity:Zone:#{zoneMetrics[:name]}", 'Electricity Annual Value', 'GJ', 'kWh').round(2)
 
-      vals[:vt] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Gas', "InteriorEquipment:Gas:Zone:#{zoneMetrics[:name]}", 'Gas Maximum  Value', 'W', 'kBtu/hr').round(2)
-      vals[:vu] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Gas', "InteriorEquipment:Gas:Zone:#{zoneMetrics[:name]}", 'Timestamp of Maximum', '', 's')
+      vals[:vt] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Natural Gas', "InteriorEquipment:NaturalGas:Zone:#{zoneMetrics[:name]}", 'Natural Gas Maximum Value', 'W', 'kBtu/hr').round(2)
+      vals[:vu] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Natural Gas', "InteriorEquipment:NaturalGas:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
 
       vals[:vv] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorLights:Electricity:Zone:#{zoneMetrics[:name]}", 'Electricity Maximum Value', 'W', 'kW').round(2)
-      vals[:vw] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorLights:Electricity:Zone:#{zoneMetrics[:name]}", 'Timestamp of Maximum', '', 's')
+      vals[:vw] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorLights:Electricity:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
 
       # X unused
 
       vals[:vy] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorEquipment:Electricity:Zone:#{zoneMetrics[:name]}", 'Electricity Maximum Value', 'W', 'kW').round(2)
-      vals[:vz] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorEquipment:Electricity:Zone:#{zoneMetrics[:name]}", 'Timestamp of Maximum', '', 's')
+      vals[:vz] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Electricity', "InteriorEquipment:Electricity:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
 
-      vals[:vaa] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "InteriorEquipment:DistrictHeating:Zone:#{zoneMetrics[:name]}", 'Annual Value', 'GJ', 'kBtu').round(2)
-      vals[:vab] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "InteriorEquipment:DistrictHeating:Zone:#{zoneMetrics[:name]}", 'Maximum Value', 'W', 'kBtu/hr').round(2)
-      vals[:vac] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "InteriorEquipment:DistrictHeating:Zone:#{zoneMetrics[:name]}", 'Timestamp of Maximum', '', 's')
+      vals[:vaa] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "InteriorEquipment:DistrictHeatingWater:Zone:#{zoneMetrics[:name]}", 'Annual Value', 'GJ', 'kBtu').round(2)
+      vals[:vab] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "InteriorEquipment:DistrictHeatingWater:Zone:#{zoneMetrics[:name]}", 'Maximum Value', 'W', 'kBtu/hr').round(2)
+      vals[:vac] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "InteriorEquipment:DistrictHeatingWater:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
 
       vals[:vad] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Heating:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Annual Value', 'GJ', 'kBtu').round(2)
       vals[:vae] = (getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Heating:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Maximum Value', 'W', 'kBtu/hr') / zoneMetrics[:area]).round(2)
-      vals[:vaf] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Heating:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Timestamp of Maximum', '', 's')
+      vals[:vaf] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Heating:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
 
       vals[:vag] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Cooling:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Annual Value', 'GJ', 'kBtu').round(2)
       vals[:vah] = (getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Cooling:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Maximum Value', 'W', 'kBtu/hr') / zoneMetrics[:area]).round(2)
-      vals[:vai] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Cooling:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Timestamp of Maximum', '', 's')
+      vals[:vai] = getDetailsData('EnergyMeters', 'Entire Facility', 'Annual and Peak Values - Other', "Cooling:EnergyTransfer:Zone:#{zoneMetrics[:name]}", 'Timestamp of Minimum {TIMESTAMP}', '', 's')
 
       vals[:vaj] = zoneHeatComponentCalc('People', zoneMetrics)
       vals[:vak] = zoneHeatComponentCalc('Lights', zoneMetrics)

--- a/lib/measures/ZoneReport/tests/ZoneReport_Test.rb
+++ b/lib/measures/ZoneReport/tests/ZoneReport_Test.rb
@@ -200,6 +200,10 @@ class ZoneReport_Test < Minitest::Test
       result = runner.result
       show_output(result)
       assert_equal('Success', result.value.valueName)
+
+      # fail test if warning
+      assert_equal(0, result.warnings.size)
+
     ensure
       Dir.chdir(start_dir)
     end

--- a/lib/measures/ZoneReport/tests/gas_electric_mark_load.osm
+++ b/lib/measures/ZoneReport/tests/gas_electric_mark_load.osm
@@ -4578,11 +4578,11 @@ OS:DefaultScheduleSet,
   {cdc340a8-7617-420e-b7d9-f0d518d9bdf3}, !- People Activity Level Schedule Name
   {519f1393-154f-48a3-abf3-b4259184f75a}, !- Lighting Schedule Name
   {afb7c502-efcf-4588-8f7f-d170513af535}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
+  {afb7c502-efcf-4588-8f7f-d170513af535}, !- Gas Equipment Schedule Name
   ,                                       !- Hot Water Equipment Schedule Name
   {9b632351-6f29-44df-8db8-ea74fdb73fd9}, !- Infiltration Schedule Name
   ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
+  {afb7c502-efcf-4588-8f7f-d170513af535}; !- Other Equipment Schedule Name
 
 OS:Lights:Definition,
   {40a1e206-1ba7-493a-bc91-516e63eee985}, !- Handle
@@ -5563,12 +5563,12 @@ OS:DefaultScheduleSet,
   {3f2c281b-2880-437c-9ba2-bc3dedff516c}, !- Number of People Schedule Name
   {cdc340a8-7617-420e-b7d9-f0d518d9bdf3}, !- People Activity Level Schedule Name
   {519f1393-154f-48a3-abf3-b4259184f75a}, !- Lighting Schedule Name
-  ,                                       !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
+  {afb7c502-efcf-4588-8f7f-d170513af535}, !- Electric Equipment Schedule Name
+  {afb7c502-efcf-4588-8f7f-d170513af535}, !- Gas Equipment Schedule Name
   ,                                       !- Hot Water Equipment Schedule Name
   {9b632351-6f29-44df-8db8-ea74fdb73fd9}, !- Infiltration Schedule Name
   ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
+  {afb7c502-efcf-4588-8f7f-d170513af535}; !- Other Equipment Schedule Name
 
 OS:Lights:Definition,
   {da1f6e19-7c6d-423c-85a8-c6c0bf75e578}, !- Handle
@@ -5678,11 +5678,11 @@ OS:DefaultScheduleSet,
   {cdc340a8-7617-420e-b7d9-f0d518d9bdf3}, !- People Activity Level Schedule Name
   {519f1393-154f-48a3-abf3-b4259184f75a}, !- Lighting Schedule Name
   {afb7c502-efcf-4588-8f7f-d170513af535}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
+  {afb7c502-efcf-4588-8f7f-d170513af535}, !- Gas Equipment Schedule Name
   ,                                       !- Hot Water Equipment Schedule Name
   {9b632351-6f29-44df-8db8-ea74fdb73fd9}, !- Infiltration Schedule Name
   ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
+  {afb7c502-efcf-4588-8f7f-d170513af535}; !- Other Equipment Schedule Name
 
 OS:Lights:Definition,
   {9df12fbe-f931-4b12-8e80-386c92927dda}, !- Handle
@@ -9185,4 +9185,38 @@ OS:Connection,
   3,                                      !- Outlet Port
   {284773c5-9560-48d6-bdfa-a47afc99cd7b}, !- Target Object
   2;                                      !- Inlet Port
+
+OS:GasEquipment:Definition,
+  {4e3c3574-4f39-417f-b850-cf5c3da6595a}, !- Handle
+  Gas Equipment Definition 1,             !- Name
+  Watts/Area,                             !- Design Level Calculation Method
+  ,                                       !- Design Level {W}
+  1,                                      !- Watts per Space Floor Area {W/m2}
+  ;                                       !- Watts per Person {W/Person}
+
+OS:GasEquipment,
+  {8d03ecaa-367f-4aaf-b821-99c678b867e6}, !- Handle
+  Gas Equipment 1,                        !- Name
+  {4e3c3574-4f39-417f-b850-cf5c3da6595a}, !- Gas Equipment Definition Name
+  {baf897ea-6e53-4c8b-8d6f-679ed46d23d4}, !- Space or SpaceType Name
+  {afb7c502-efcf-4588-8f7f-d170513af535}; !- Schedule Name
+
+OS:GasEquipment,
+  {51610a77-d8d5-4b3e-8edb-533d60603b83}, !- Handle
+  Gas Equipment 2,                        !- Name
+  {4e3c3574-4f39-417f-b850-cf5c3da6595a}, !- Gas Equipment Definition Name
+  {7150e08f-69fc-4ed1-b532-e445f24728fb}, !- Space or SpaceType Name
+  {afb7c502-efcf-4588-8f7f-d170513af535}; !- Schedule Name
+
+OS:GasEquipment,
+  {0b4ffdf0-cb83-4a0a-af0d-4ddf46d3e974}, !- Handle
+  Gas Equipment 3,                        !- Name
+  {4e3c3574-4f39-417f-b850-cf5c3da6595a}, !- Gas Equipment Definition Name
+  {b257189d-31e4-45a2-b538-64234a4c0faf}; !- Space or SpaceType Name
+
+OS:ElectricEquipment,
+  {bf63974e-2a73-4235-8f51-f424b8f70f1e}, !- Handle
+  Electric Equipment 1,                   !- Name
+  {f3370da9-e17a-446f-bd8b-2c50303ef410}, !- Electric Equipment Definition Name
+  {7150e08f-69fc-4ed1-b532-e445f24728fb}; !- Space or SpaceType Name
 

--- a/lib/measures/ZoneReport/tests/gas_electric_mark_load.osm
+++ b/lib/measures/ZoneReport/tests/gas_electric_mark_load.osm
@@ -3,50 +3,12 @@ OS:Version,
   {2619175a-f066-4d58-a88b-dadcaa67ebba}, !- Handle
   1.5.0;                                  !- Version Identifier
 
-OS:SpaceType,
-  {d83c9d8c-b4ea-4352-92bc-43a5e8551039}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ1-3, !- Name
-  ,                                       !- Default Construction Set Name
-  {3f64b7db-745b-40b0-bb02-6ec871a396ef}, !- Default Schedule Set Name
-  {d1e86687-6885-4070-81da-3a576f17ff5c}, !- Group Rendering Name
-  {67f2822d-9200-410d-bad4-ca1adb4cbb77}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  BreakRoom;                              !- Standards Space Type
-
 OS:Rendering:Color,
   {d1e86687-6885-4070-81da-3a576f17ff5c}, !- Handle
   Rendering Color 1,                      !- Name
   230,                                    !- Rendering Red Value
   157,                                    !- Rendering Green Value
   120;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {3f64b7db-745b-40b0-bb02-6ec871a396ef}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {2be0344f-10c3-4095-86fd-81db27963ad5}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  11.6250232500465,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {8d653251-85b6-4f77-81d6-0d1ce4ea7ee7}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ1-3 Lights, !- Name
-  {2be0344f-10c3-4095-86fd-81db27963ad5}, !- Lights Definition Name
-  {d83c9d8c-b4ea-4352-92bc-43a5e8551039}; !- Space or SpaceType Name
 
 OS:Schedule:Ruleset,
   {8a273f29-9e00-4685-a53d-4e9734fa3bef}, ! Handle
@@ -194,21 +156,6 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {c42e1fab-f69a-49d5-a2c9-f14f1259af26}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.538195520835486,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {33239cd1-ad9a-4eea-84a8-7128e0617789}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ1-3 People, !- Name
-  {c42e1fab-f69a-49d5-a2c9-f14f1259af26}, !- People Definition Name
-  {d83c9d8c-b4ea-4352-92bc-43a5e8551039}; !- Space or SpaceType Name
-
 OS:Schedule:Ruleset,
   {be0538a4-3720-422e-85be-2e617795d558}, ! Handle
   Office Misc Occ,                        ! Name
@@ -335,14 +282,6 @@ OS:Schedule:Day,
   0,                                      !- Minute 5
   0;                                      !- Value Until Time 5
 
-OS:Schedule:Ruleset,
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, ! Handle
-  Office Activity,                        ! Name
-  {65bf6a03-1758-4903-8383-db583a09d8f8}, ! Schedule Type Limits Name
-  {3327af75-d065-4569-8f41-90aaaadb46d9}, ! Default Day Schedule Name
-  {82481ab0-fa29-4f90-b6c0-269200534d1a}, ! Summer Design Day Schedule Name
-  {ce7a9c35-95ca-4940-ae5d-8bb25d884027}; ! Winter Design Day Schedule Name
-
 OS:ScheduleTypeLimits,
   {65bf6a03-1758-4903-8383-db583a09d8f8}, !- Handle
   ActivityLevel,                          !- Name
@@ -350,48 +289,6 @@ OS:ScheduleTypeLimits,
   ,                                       !- Upper Limit Value {BasedOnField A4}
   Continuous,                             !- Numeric Type
   ActivityLevel;                          !- Unit Type
-
-OS:Schedule:Day,
-  {3327af75-d065-4569-8f41-90aaaadb46d9}, ! Handle
-  Office Activity Default Schedule,       ! Name
-  {65bf6a03-1758-4903-8383-db583a09d8f8}, ! Schedule Type Limits Name
-  ,                                       ! Interpolate to Timestep
-  24,                                     !- Hour 1
-  0,                                      !- Minute 1
-  132;                                    !- Value Until Time 1
-
-OS:Schedule:Day,
-  {82481ab0-fa29-4f90-b6c0-269200534d1a}, ! Handle
-  Office Activity Summer Design Day,      ! Name
-  {65bf6a03-1758-4903-8383-db583a09d8f8}, ! Schedule Type Limits Name
-  ,                                       ! Interpolate to Timestep
-  24,                                     !- Hour 1
-  0,                                      !- Minute 1
-  132;                                    !- Value Until Time 1
-
-OS:Schedule:Day,
-  {ce7a9c35-95ca-4940-ae5d-8bb25d884027}, ! Handle
-  Office Activity Winter Design Day,      ! Name
-  {65bf6a03-1758-4903-8383-db583a09d8f8}, ! Schedule Type Limits Name
-  ,                                       ! Interpolate to Timestep
-  24,                                     !- Hour 1
-  0,                                      !- Minute 1
-  132;                                    !- Value Until Time 1
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {d11f3814-047f-4553-8741-be6dbd4a756d}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ1-3 Infiltration, !- Name
-  {d83c9d8c-b4ea-4352-92bc-43a5e8551039}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
 
 OS:Schedule:Ruleset,
   {5071fc8f-2a43-420e-b853-89de3fd548e0}, ! Handle
@@ -509,20 +406,6 @@ OS:Schedule:Day,
   24,                                     ! Hour 3
   0,                                      ! Minute 3
   1;                                      ! Value Until Time 3
-
-OS:ElectricEquipment:Definition,
-  {67250caf-92b5-4b98-bf98-90620f2922e7}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  48.0070404585254,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {077ed202-9856-487a-81f9-2b33f6ef021d}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ1-3 Electric Equipment, !- Name
-  {67250caf-92b5-4b98-bf98-90620f2922e7}, !- Electric Equipment Definition Name
-  {d83c9d8c-b4ea-4352-92bc-43a5e8551039}; !- Space or SpaceType Name
 
 OS:Schedule:Ruleset,
   {d4102340-9627-4371-b8f6-a3790caa5373}, ! Handle
@@ -888,50 +771,12 @@ OS:Schedule:Day,
   0,                                      ! Minute 3
   26.699999999999999;                     ! Value Until Time 3
 
-OS:SpaceType,
-  {3c12e344-f3c2-46e8-94cc-aa11adda3228}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ1-3, !- Name
-  ,                                       !- Default Construction Set Name
-  {9b9fb4b7-7437-423f-a42a-1e1800e6055c}, !- Default Schedule Set Name
-  {a57916a4-2d44-41b9-a1e1-917f01e6e980}, !- Group Rendering Name
-  {f46c6550-abd3-4dc9-b2fd-3521e6458afe}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  ClosedOffice;                           !- Standards Space Type
-
 OS:Rendering:Color,
   {a57916a4-2d44-41b9-a1e1-917f01e6e980}, !- Handle
   Rendering Color 2,                      !- Name
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {9b9fb4b7-7437-423f-a42a-1e1800e6055c}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {3f7fc9e5-6ce2-4b91-9fc6-85d1867c2216}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {06799bf2-e498-4941-a66b-f78cb208dc67}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  10.6562713125426,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {f1628569-1691-49f0-9348-f92fa25bb1b6}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ1-3 Lights, !- Name
-  {06799bf2-e498-4941-a66b-f78cb208dc67}, !- Lights Definition Name
-  {3c12e344-f3c2-46e8-94cc-aa11adda3228}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {f46c6550-abd3-4dc9-b2fd-3521e6458afe}, !- Handle
@@ -942,21 +787,6 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Rate {m3/s}
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
-
-OS:People:Definition,
-  {6e7c5923-7c0d-48b7-9a3f-216e3e766b71}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0511285744793712,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {5c410b4a-537a-47b7-b730-dc303931c19c}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ1-3 People, !- Name
-  {6e7c5923-7c0d-48b7-9a3f-216e3e766b71}, !- People Definition Name
-  {3c12e344-f3c2-46e8-94cc-aa11adda3228}; !- Space or SpaceType Name
 
 OS:Schedule:Ruleset,
   {3f7fc9e5-6ce2-4b91-9fc6-85d1867c2216}, ! Handle
@@ -1096,50 +926,11 @@ OS:Schedule:Day,
   0,                                      !- Minute 5
   0;                                      !- Value Until Time 5
 
-OS:SpaceInfiltration:DesignFlowRate,
-  {238b2c42-2ac7-458f-861b-9b2e338631c9}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ1-3 Infiltration, !- Name
-  {3c12e344-f3c2-46e8-94cc-aa11adda3228}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {5e1004b6-95f1-43ca-b770-059ae9545327}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  6.88890266669422,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {bb93da29-6686-468f-b8e1-c0e981827eae}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ1-3 Electric Equipment, !- Name
-  {5e1004b6-95f1-43ca-b770-059ae9545327}, !- Electric Equipment Definition Name
-  {3c12e344-f3c2-46e8-94cc-aa11adda3228}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {b27de14f-0cdf-4395-80f3-859d49e9b403}, !- Handle
   189.1-2009 - Office - ClosedOffice - CZ1-3 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {47604387-8748-48ff-835b-5f4e110a8059}, !- Handle
-  189.1-2009 - Office - Conference - CZ1-3, !- Name
-  ,                                       !- Default Construction Set Name
-  {e3b81960-34e9-43e9-802b-72dc932ec324}, !- Default Schedule Set Name
-  {ec05571d-f09e-46c5-830e-02e7c83716e2}, !- Group Rendering Name
-  {a1ac4f23-b7fd-439b-9144-9025bbf81b99}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Conference;                             !- Standards Space Type
 
 OS:Rendering:Color,
   {ec05571d-f09e-46c5-830e-02e7c83716e2}, !- Handle
@@ -1147,34 +938,6 @@ OS:Rendering:Color,
   230,                                    !- Rendering Red Value
   196,                                    !- Rendering Green Value
   120;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {e3b81960-34e9-43e9-802b-72dc932ec324}, !- Handle
-  189.1-2009 - Office - Conference - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {7c05f735-2072-4b8c-946d-b7cd8119ee11}, !- Handle
-  189.1-2009 - Office - Conference - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  12.5937751875504,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {277ed265-0401-47f6-8de3-56cb05b9fea5}, !- Handle
-  189.1-2009 - Office - Conference - CZ1-3 Lights, !- Name
-  {7c05f735-2072-4b8c-946d-b7cd8119ee11}, !- Lights Definition Name
-  {47604387-8748-48ff-835b-5f4e110a8059}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {a1ac4f23-b7fd-439b-9144-9025bbf81b99}, !- Handle
@@ -1186,65 +949,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {1e057bcd-e909-4141-b7ac-844fc9c736b0}, !- Handle
-  189.1-2009 - Office - Conference - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.538195520835486,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {8e273f12-7404-4658-8039-d1b0d9e7d0e1}, !- Handle
-  189.1-2009 - Office - Conference - CZ1-3 People, !- Name
-  {1e057bcd-e909-4141-b7ac-844fc9c736b0}, !- People Definition Name
-  {47604387-8748-48ff-835b-5f4e110a8059}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {de1ea70d-57dc-4928-a47f-57f514ec3603}, !- Handle
-  189.1-2009 - Office - Conference - CZ1-3 Infiltration, !- Name
-  {47604387-8748-48ff-835b-5f4e110a8059}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {24acb6cb-ad2a-44b2-b01a-335e7395daae}, !- Handle
-  189.1-2009 - Office - Conference - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  3.9826468541826,                        !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {980641d4-cbda-4a28-868d-304978627e4f}, !- Handle
-  189.1-2009 - Office - Conference - CZ1-3 Electric Equipment, !- Name
-  {24acb6cb-ad2a-44b2-b01a-335e7395daae}, !- Electric Equipment Definition Name
-  {47604387-8748-48ff-835b-5f4e110a8059}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {9c5a236d-b8fa-4e61-a6d6-5ef82442b61b}, !- Handle
   189.1-2009 - Office - Conference - CZ1-3 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {911f473e-1c50-43ba-b507-1b4167677ea0}, !- Handle
-  189.1-2009 - Office - Corridor - CZ1-3, !- Name
-  ,                                       !- Default Construction Set Name
-  {60152e25-975f-42e9-a93e-854a20be3577}, !- Default Schedule Set Name
-  {9637cafc-bc8f-40aa-8756-39cbbba37ac4}, !- Group Rendering Name
-  {43c2eb8f-ca41-472d-a661-37d29e1aa470}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Corridor;                               !- Standards Space Type
 
 OS:Rendering:Color,
   {9637cafc-bc8f-40aa-8756-39cbbba37ac4}, !- Handle
@@ -1252,34 +961,6 @@ OS:Rendering:Color,
   169,                                    !- Rendering Red Value
   31,                                     !- Rendering Green Value
   31;                                     !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {60152e25-975f-42e9-a93e-854a20be3577}, !- Handle
-  189.1-2009 - Office - Corridor - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {3f7fc9e5-6ce2-4b91-9fc6-85d1867c2216}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {61d53d0d-2d54-4a69-926d-aeb7fd47d282}, !- Handle
-  189.1-2009 - Office - Corridor - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  4.84375968751938,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {97345961-c39c-4800-be47-fd365cf09579}, !- Handle
-  189.1-2009 - Office - Corridor - CZ1-3 Lights, !- Name
-  {61d53d0d-2d54-4a69-926d-aeb7fd47d282}, !- Lights Definition Name
-  {911f473e-1c50-43ba-b507-1b4167677ea0}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {43c2eb8f-ca41-472d-a661-37d29e1aa470}, !- Handle
@@ -1291,65 +972,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {15f0501f-443a-40f6-846f-5720de6f91e8}, !- Handle
-  189.1-2009 - Office - Corridor - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0107639104167097,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {7f505a51-9e01-4f8c-ae6b-eb3a985187f9}, !- Handle
-  189.1-2009 - Office - Corridor - CZ1-3 People, !- Name
-  {15f0501f-443a-40f6-846f-5720de6f91e8}, !- People Definition Name
-  {911f473e-1c50-43ba-b507-1b4167677ea0}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {d288d3ec-bb21-459b-96e3-62f849faafec}, !- Handle
-  189.1-2009 - Office - Corridor - CZ1-3 Infiltration, !- Name
-  {911f473e-1c50-43ba-b507-1b4167677ea0}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {3e9e4b9d-78ea-42f5-87ca-c1ec4f4990f2}, !- Handle
-  189.1-2009 - Office - Corridor - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  1.72222566667356,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {f21b9dab-a69e-476b-96be-93f1f5fee1c6}, !- Handle
-  189.1-2009 - Office - Corridor - CZ1-3 Electric Equipment, !- Name
-  {3e9e4b9d-78ea-42f5-87ca-c1ec4f4990f2}, !- Electric Equipment Definition Name
-  {911f473e-1c50-43ba-b507-1b4167677ea0}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {52549264-a360-4f7a-971d-ec4f2499546a}, !- Handle
   189.1-2009 - Office - Corridor - CZ1-3 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {c35a045e-a8b7-4634-a314-0f2c9fd21361}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ1-3, !- Name
-  ,                                       !- Default Construction Set Name
-  {7034f523-a923-4bff-bcec-e836877b0d3b}, !- Default Schedule Set Name
-  {8a8c0cb1-8336-469c-bca4-e17997f803bb}, !- Group Rendering Name
-  {69d02fbd-3b65-4514-8330-355612e92de3}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Elec/MechRoom;                          !- Standards Space Type
 
 OS:Rendering:Color,
   {8a8c0cb1-8336-469c-bca4-e17997f803bb}, !- Handle
@@ -1357,34 +984,6 @@ OS:Rendering:Color,
   41,                                     !- Rendering Red Value
   31,                                     !- Rendering Green Value
   169;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {7034f523-a923-4bff-bcec-e836877b0d3b}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  ,                                       !- Number of People Schedule Name
-  ,                                       !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {db4f58dd-4414-4c10-8481-b5fdd7610a22}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  14.5312790625581,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {8de70c6d-3c20-4a5a-95f3-70ab2a37759d}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ1-3 Lights, !- Name
-  {db4f58dd-4414-4c10-8481-b5fdd7610a22}, !- Lights Definition Name
-  {c35a045e-a8b7-4634-a314-0f2c9fd21361}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {69d02fbd-3b65-4514-8330-355612e92de3}, !- Handle
@@ -1396,50 +995,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:SpaceInfiltration:DesignFlowRate,
-  {6e96cbfa-7560-4e78-aa8c-239431fd271e}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ1-3 Infiltration, !- Name
-  {c35a045e-a8b7-4634-a314-0f2c9fd21361}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {bfdd4c3c-95fa-4c2d-8597-8431da48afda}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  2.90625581251162,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {b17982ba-d5dd-42bf-8d61-12b8c10eee84}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ1-3 Electric Equipment, !- Name
-  {bfdd4c3c-95fa-4c2d-8597-8431da48afda}, !- Electric Equipment Definition Name
-  {c35a045e-a8b7-4634-a314-0f2c9fd21361}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {f8635cc8-deee-4e85-815b-ff7f42668c83}, !- Handle
   189.1-2009 - Office - Elec/MechRoom - CZ1-3 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {b904fa71-fec8-4e29-89a1-d0386138c5a6}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ1-3,  !- Name
-  ,                                       !- Default Construction Set Name
-  {ba84ee14-7d89-4e59-8d59-625209be8ce9}, !- Default Schedule Set Name
-  {20b4e546-0bb5-45c4-b8f0-ba4246a49c01}, !- Group Rendering Name
-  {2f4b0680-26b1-4103-9f70-412db3ebdfbe}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  IT_Room;                                !- Standards Space Type
 
 OS:Rendering:Color,
   {20b4e546-0bb5-45c4-b8f0-ba4246a49c01}, !- Handle
@@ -1447,34 +1007,6 @@ OS:Rendering:Color,
   41,                                     !- Rendering Red Value
   31,                                     !- Rendering Green Value
   169;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {ba84ee14-7d89-4e59-8d59-625209be8ce9}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {a6747de8-6448-4e86-abde-d12da5652867}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  10.6562713125426,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {1c9042b5-d85b-4aa1-b403-f1f57ffa5e80}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ1-3 Lights, !- Name
-  {a6747de8-6448-4e86-abde-d12da5652867}, !- Lights Definition Name
-  {b904fa71-fec8-4e29-89a1-d0386138c5a6}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {2f4b0680-26b1-4103-9f70-412db3ebdfbe}, !- Handle
@@ -1486,65 +1018,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {ad090db3-4049-4090-9b2d-581dd03ae523}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0538195520835486,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {0e08e98a-89ff-440c-98ff-477b7c3fbca4}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ1-3 People, !- Name
-  {ad090db3-4049-4090-9b2d-581dd03ae523}, !- People Definition Name
-  {b904fa71-fec8-4e29-89a1-d0386138c5a6}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {f3738484-ddae-4171-9149-4056023e0061}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ1-3 Infiltration, !- Name
-  {b904fa71-fec8-4e29-89a1-d0386138c5a6}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {2d5fe187-829f-4492-a2a6-f83bc2f40cec}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  16.7917002500672,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {d754310d-f9d1-4b56-8a61-4d2a167b0f57}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ1-3 Electric Equipment, !- Name
-  {2d5fe187-829f-4492-a2a6-f83bc2f40cec}, !- Electric Equipment Definition Name
-  {b904fa71-fec8-4e29-89a1-d0386138c5a6}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {7669758f-56e6-4440-9266-ef142961841f}, !- Handle
   189.1-2009 - Office - IT_Room - CZ1-3 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {1afa8972-0451-45b3-8dda-3a3a776e008b}, !- Handle
-  189.1-2009 - Office - Lobby - CZ1-3,    !- Name
-  ,                                       !- Default Construction Set Name
-  {e0c21456-bd44-4237-8936-486557ac00f6}, !- Default Schedule Set Name
-  {0e5a132c-e7c3-4583-ad5a-cf0bf0fe2d03}, !- Group Rendering Name
-  {f648ca0a-523e-4cd1-9141-0b84b7a81954}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Lobby;                                  !- Standards Space Type
 
 OS:Rendering:Color,
   {0e5a132c-e7c3-4583-ad5a-cf0bf0fe2d03}, !- Handle
@@ -1552,34 +1030,6 @@ OS:Rendering:Color,
   230,                                    !- Rendering Red Value
   157,                                    !- Rendering Green Value
   120;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {e0c21456-bd44-4237-8936-486557ac00f6}, !- Handle
-  189.1-2009 - Office - Lobby - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {aa532c04-012a-4860-ab4d-2c03c2c7fa04}, !- Handle
-  189.1-2009 - Office - Lobby - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  12.5937751875504,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {28cb410d-135d-49f1-b23c-6218793a6744}, !- Handle
-  189.1-2009 - Office - Lobby - CZ1-3 Lights, !- Name
-  {aa532c04-012a-4860-ab4d-2c03c2c7fa04}, !- Lights Definition Name
-  {1afa8972-0451-45b3-8dda-3a3a776e008b}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {f648ca0a-523e-4cd1-9141-0b84b7a81954}, !- Handle
@@ -1591,65 +1041,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {91f1c38f-68a1-4305-b70a-a3e1fbc3f83a}, !- Handle
-  189.1-2009 - Office - Lobby - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.107639104167097,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {c9c2acc5-e4d4-49b4-9a7e-94cae06ac406}, !- Handle
-  189.1-2009 - Office - Lobby - CZ1-3 People, !- Name
-  {91f1c38f-68a1-4305-b70a-a3e1fbc3f83a}, !- People Definition Name
-  {1afa8972-0451-45b3-8dda-3a3a776e008b}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {61535505-edb5-4881-9380-6ceb9c94ccaa}, !- Handle
-  189.1-2009 - Office - Lobby - CZ1-3 Infiltration, !- Name
-  {1afa8972-0451-45b3-8dda-3a3a776e008b}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {d64c15fd-a2f8-4262-81e5-ab028c6506a1}, !- Handle
-  189.1-2009 - Office - Lobby - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  0.753473729169681,                      !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {9bdcf653-9208-444f-abd4-40bc6d797f8a}, !- Handle
-  189.1-2009 - Office - Lobby - CZ1-3 Electric Equipment, !- Name
-  {d64c15fd-a2f8-4262-81e5-ab028c6506a1}, !- Electric Equipment Definition Name
-  {1afa8972-0451-45b3-8dda-3a3a776e008b}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {f63de19d-9cf2-4162-bf2f-bdb7fddc1b7d}, !- Handle
   189.1-2009 - Office - Lobby - CZ1-3 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {be8c0991-a26a-4dda-ae53-b3249804ebf9}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ1-3, !- Name
-  ,                                       !- Default Construction Set Name
-  {036543da-4144-409d-981b-4ddf12ce677e}, !- Default Schedule Set Name
-  {e1b28003-ba15-4183-b5d9-585f72709eff}, !- Group Rendering Name
-  {f57d4115-03b8-4303-b205-42221bda4210}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  OpenOffice;                             !- Standards Space Type
 
 OS:Rendering:Color,
   {e1b28003-ba15-4183-b5d9-585f72709eff}, !- Handle
@@ -1657,34 +1053,6 @@ OS:Rendering:Color,
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {036543da-4144-409d-981b-4ddf12ce677e}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {3f7fc9e5-6ce2-4b91-9fc6-85d1867c2216}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {6c9d9254-9bb8-426a-af9b-3677316cf238}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  10.6562713125426,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {1b233aa2-884a-4b12-bd88-76092f6d2267}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ1-3 Lights, !- Name
-  {6c9d9254-9bb8-426a-af9b-3677316cf238}, !- Lights Definition Name
-  {be8c0991-a26a-4dda-ae53-b3249804ebf9}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {f57d4115-03b8-4303-b205-42221bda4210}, !- Handle
@@ -1695,50 +1063,6 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Rate {m3/s}
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
-
-OS:People:Definition,
-  {0e75bef1-0c07-4d0b-822d-d2df7c6f1111}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.056510529687726,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {30d60591-72de-4494-afc4-000c9be76f8b}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ1-3 People, !- Name
-  {0e75bef1-0c07-4d0b-822d-d2df7c6f1111}, !- People Definition Name
-  {be8c0991-a26a-4dda-ae53-b3249804ebf9}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {ef0be415-7a7a-4be9-895a-fefe67ce5d3e}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ1-3 Infiltration, !- Name
-  {be8c0991-a26a-4dda-ae53-b3249804ebf9}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {6b2d3c23-bd59-4857-b849-eaf6b4a64e2f}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  7.6423763958639,                        !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {1e0e1e3c-6473-41c2-ace8-efda06663fe0}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ1-3 Electric Equipment, !- Name
-  {6b2d3c23-bd59-4857-b849-eaf6b4a64e2f}, !- Electric Equipment Definition Name
-  {be8c0991-a26a-4dda-ae53-b3249804ebf9}; !- Space or SpaceType Name
 
 OS:ThermostatSetpoint:DualSetpoint,
   {b88ada7e-5b66-4c29-8b49-7f9040c59933}, !- Handle
@@ -1759,50 +1083,12 @@ OS:Building,
   ,                                       !- Standards Number of Above Ground Stories
   ;                                       !- Standards Building Type
 
-OS:SpaceType,
-  {c0190c37-61e0-43b8-b980-313f616f75af}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ1-3, !- Name
-  ,                                       !- Default Construction Set Name
-  {7b266719-acd7-491e-9cdb-d0f00a5dfec4}, !- Default Schedule Set Name
-  {061734ce-19f4-4c27-a203-4b67b00d47ac}, !- Group Rendering Name
-  {107e2dcf-081d-47d9-b8b0-921f5279392b}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  PrintRoom;                              !- Standards Space Type
-
 OS:Rendering:Color,
   {061734ce-19f4-4c27-a203-4b67b00d47ac}, !- Handle
   Rendering Color 9,                      !- Name
   41,                                     !- Rendering Red Value
   31,                                     !- Rendering Green Value
   169;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {7b266719-acd7-491e-9cdb-d0f00a5dfec4}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {7a23b936-59e3-4314-9b52-3944ebdea4dc}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  10.6562713125426,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {1979f9cd-f801-4f74-b848-c88f17dc5b44}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ1-3 Lights, !- Name
-  {7a23b936-59e3-4314-9b52-3944ebdea4dc}, !- Lights Definition Name
-  {c0190c37-61e0-43b8-b980-313f616f75af}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {107e2dcf-081d-47d9-b8b0-921f5279392b}, !- Handle
@@ -1814,65 +1100,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {1e43b6dd-36da-4525-88ab-833e4310a5da}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.107639104167097,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {673d36c1-b361-47e7-9007-e4e91432cb81}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ1-3 People, !- Name
-  {1e43b6dd-36da-4525-88ab-833e4310a5da}, !- People Definition Name
-  {c0190c37-61e0-43b8-b980-313f616f75af}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {e520996e-cb4e-4946-ae4e-12637ab956f9}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ1-3 Infiltration, !- Name
-  {c0190c37-61e0-43b8-b980-313f616f75af}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {174d96d7-8543-478a-a5f4-76314ad6b67f}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  30.0313100626201,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {13850150-ad18-438c-906d-18f8cabcbdf5}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ1-3 Electric Equipment, !- Name
-  {174d96d7-8543-478a-a5f4-76314ad6b67f}, !- Electric Equipment Definition Name
-  {c0190c37-61e0-43b8-b980-313f616f75af}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {cb7fb571-b062-476f-8b81-9ee2aa7be729}, !- Handle
   189.1-2009 - Office - PrintRoom - CZ1-3 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {a818abd3-e1c5-4d15-9f17-96bb76777e4b}, !- Handle
-  189.1-2009 - Office - Restroom - CZ1-3, !- Name
-  ,                                       !- Default Construction Set Name
-  {2cb74439-6b94-4bdb-bc70-0ca10c0d3b2e}, !- Default Schedule Set Name
-  {e64f5cb7-2c3d-45a9-84a6-367125f15aff}, !- Group Rendering Name
-  {65cf1445-a2aa-42ad-9ff8-c4b30ec4e53d}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Restroom;                               !- Standards Space Type
 
 OS:Rendering:Color,
   {e64f5cb7-2c3d-45a9-84a6-367125f15aff}, !- Handle
@@ -1880,34 +1112,6 @@ OS:Rendering:Color,
   169,                                    !- Rendering Red Value
   169,                                    !- Rendering Green Value
   31;                                     !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {2cb74439-6b94-4bdb-bc70-0ca10c0d3b2e}, !- Handle
-  189.1-2009 - Office - Restroom - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {16c83f7f-a90c-43cd-99b3-fe5b6f146132}, !- Handle
-  189.1-2009 - Office - Restroom - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  8.71876743753488,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {3120c45b-328a-43ca-b763-11e879fb3a84}, !- Handle
-  189.1-2009 - Office - Restroom - CZ1-3 Lights, !- Name
-  {16c83f7f-a90c-43cd-99b3-fe5b6f146132}, !- Lights Definition Name
-  {a818abd3-e1c5-4d15-9f17-96bb76777e4b}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {65cf1445-a2aa-42ad-9ff8-c4b30ec4e53d}, !- Handle
@@ -1919,65 +1123,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {134d060a-3bfc-40bd-bda0-b77a4720c9c2}, !- Handle
-  189.1-2009 - Office - Restroom - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.107639104167097,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {4bd834f4-5ae4-4146-8dbd-c600ee119692}, !- Handle
-  189.1-2009 - Office - Restroom - CZ1-3 People, !- Name
-  {134d060a-3bfc-40bd-bda0-b77a4720c9c2}, !- People Definition Name
-  {a818abd3-e1c5-4d15-9f17-96bb76777e4b}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {6d0ceae2-80c3-45c0-a634-2929c8a56678}, !- Handle
-  189.1-2009 - Office - Restroom - CZ1-3 Infiltration, !- Name
-  {a818abd3-e1c5-4d15-9f17-96bb76777e4b}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {6330081f-04c2-429c-adff-1624fc497cd6}, !- Handle
-  189.1-2009 - Office - Restroom - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  0.753473729169681,                      !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {569209c0-ef8b-44f5-9f86-048af1de9fa7}, !- Handle
-  189.1-2009 - Office - Restroom - CZ1-3 Electric Equipment, !- Name
-  {6330081f-04c2-429c-adff-1624fc497cd6}, !- Electric Equipment Definition Name
-  {a818abd3-e1c5-4d15-9f17-96bb76777e4b}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {36f7e68a-a20c-471b-b929-d4756cba022f}, !- Handle
   189.1-2009 - Office - Restroom - CZ1-3 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {531dd228-de8a-4d34-9988-9ac8d77877a0}, !- Handle
-  189.1-2009 - Office - Stair - CZ1-3,    !- Name
-  ,                                       !- Default Construction Set Name
-  {63837c20-3153-4ace-86c9-1d8bf8b43d7a}, !- Default Schedule Set Name
-  {d956b768-7de2-4589-97c3-e0178f40b773}, !- Group Rendering Name
-  {65e99483-2d7e-4ca8-9e0d-a7914f938f56}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Stair;                                  !- Standards Space Type
 
 OS:Rendering:Color,
   {d956b768-7de2-4589-97c3-e0178f40b773}, !- Handle
@@ -1985,34 +1135,6 @@ OS:Rendering:Color,
   230,                                    !- Rendering Red Value
   157,                                    !- Rendering Green Value
   120;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {63837c20-3153-4ace-86c9-1d8bf8b43d7a}, !- Handle
-  189.1-2009 - Office - Stair - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  ,                                       !- Number of People Schedule Name
-  ,                                       !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  ,                                       !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {b70563e1-7e2b-4c90-b280-61fcf401da4c}, !- Handle
-  189.1-2009 - Office - Stair - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  5.81251162502325,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {3637974c-a21a-4d9a-9a86-de0b34a41576}, !- Handle
-  189.1-2009 - Office - Stair - CZ1-3 Lights, !- Name
-  {b70563e1-7e2b-4c90-b280-61fcf401da4c}, !- Lights Definition Name
-  {531dd228-de8a-4d34-9988-9ac8d77877a0}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {65e99483-2d7e-4ca8-9e0d-a7914f938f56}, !- Handle
@@ -2024,36 +1146,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:SpaceInfiltration:DesignFlowRate,
-  {b55008d6-57ec-4a59-853d-dc295ea83be3}, !- Handle
-  189.1-2009 - Office - Stair - CZ1-3 Infiltration, !- Name
-  {531dd228-de8a-4d34-9988-9ac8d77877a0}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
 OS:ThermostatSetpoint:DualSetpoint,
   {8f2a6abe-ef82-4cf6-9a19-42526787c24e}, !- Handle
   189.1-2009 - Office - Stair - CZ1-3 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {355570b9-3696-4442-903b-449be8ccf16a}, !- Handle
-  189.1-2009 - Office - Storage - CZ1-3,  !- Name
-  ,                                       !- Default Construction Set Name
-  {c81d9947-159d-4809-8a7f-ae3bb2fe95fa}, !- Default Schedule Set Name
-  {40564289-28c7-4fd8-b822-fe7139d1f5bf}, !- Group Rendering Name
-  {99330741-43bc-49e4-9991-d6cf4a0ba4aa}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Storage;                                !- Standards Space Type
 
 OS:Rendering:Color,
   {40564289-28c7-4fd8-b822-fe7139d1f5bf}, !- Handle
@@ -2061,34 +1158,6 @@ OS:Rendering:Color,
   120,                                    !- Rendering Red Value
   149,                                    !- Rendering Green Value
   230;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {c81d9947-159d-4809-8a7f-ae3bb2fe95fa}, !- Handle
-  189.1-2009 - Office - Storage - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  ,                                       !- Number of People Schedule Name
-  ,                                       !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  ,                                       !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {373b8d0f-41c3-4c11-97ad-74ff4084e752}, !- Handle
-  189.1-2009 - Office - Storage - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  7.750015500031,                         !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {99c236b6-e588-4c3f-ae8e-98f257807e7c}, !- Handle
-  189.1-2009 - Office - Storage - CZ1-3 Lights, !- Name
-  {373b8d0f-41c3-4c11-97ad-74ff4084e752}, !- Lights Definition Name
-  {355570b9-3696-4442-903b-449be8ccf16a}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {99330741-43bc-49e4-9991-d6cf4a0ba4aa}, !- Handle
@@ -2100,36 +1169,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:SpaceInfiltration:DesignFlowRate,
-  {76e2e858-0e95-49d7-a5bd-46ff2e7bf75b}, !- Handle
-  189.1-2009 - Office - Storage - CZ1-3 Infiltration, !- Name
-  {355570b9-3696-4442-903b-449be8ccf16a}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
 OS:ThermostatSetpoint:DualSetpoint,
   {f8e65471-7105-4908-ae0b-ec42ae5587b5}, !- Handle
   189.1-2009 - Office - Storage - CZ1-3 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {bcd867f1-c57c-4206-9b38-1c7e254a4143}, !- Handle
-  189.1-2009 - Office - Vending - CZ1-3,  !- Name
-  ,                                       !- Default Construction Set Name
-  {c044c52f-9474-4ba2-9f45-7069de4c6b87}, !- Default Schedule Set Name
-  {cf88ad3d-58c9-452c-88c4-ac7ea371f930}, !- Group Rendering Name
-  {6dbe4189-6232-4d6e-9ac9-63d6e0ee9668}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Vending;                                !- Standards Space Type
 
 OS:Rendering:Color,
   {cf88ad3d-58c9-452c-88c4-ac7ea371f930}, !- Handle
@@ -2137,34 +1181,6 @@ OS:Rendering:Color,
   230,                                    !- Rendering Red Value
   157,                                    !- Rendering Green Value
   120;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {c044c52f-9474-4ba2-9f45-7069de4c6b87}, !- Handle
-  189.1-2009 - Office - Vending - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {dba49d56-ae67-469f-bd99-1ea63a8e50b2}, !- Handle
-  189.1-2009 - Office - Vending - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  4.84375968751938,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {57f0532e-f17a-45d3-879e-193fae9dc176}, !- Handle
-  189.1-2009 - Office - Vending - CZ1-3 Lights, !- Name
-  {dba49d56-ae67-469f-bd99-1ea63a8e50b2}, !- Lights Definition Name
-  {bcd867f1-c57c-4206-9b38-1c7e254a4143}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {6dbe4189-6232-4d6e-9ac9-63d6e0ee9668}, !- Handle
@@ -2176,65 +1192,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {b2bafb87-d4df-471b-9770-b0d82b64b0df}, !- Handle
-  189.1-2009 - Office - Vending - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0107639104167097,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {d9509edb-bd80-4225-9ee6-523bf74d5bee}, !- Handle
-  189.1-2009 - Office - Vending - CZ1-3 People, !- Name
-  {b2bafb87-d4df-471b-9770-b0d82b64b0df}, !- People Definition Name
-  {bcd867f1-c57c-4206-9b38-1c7e254a4143}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {426c18b5-7d3a-4579-b2a8-8e385458dd11}, !- Handle
-  189.1-2009 - Office - Vending - CZ1-3 Infiltration, !- Name
-  {bcd867f1-c57c-4206-9b38-1c7e254a4143}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {4c5550a6-4da3-4490-ac94-170d7b86c60a}, !- Handle
-  189.1-2009 - Office - Vending - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  41.4410551043324,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {cecff4bf-5467-4b34-a941-9654b489181d}, !- Handle
-  189.1-2009 - Office - Vending - CZ1-3 Electric Equipment, !- Name
-  {4c5550a6-4da3-4490-ac94-170d7b86c60a}, !- Electric Equipment Definition Name
-  {bcd867f1-c57c-4206-9b38-1c7e254a4143}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {de4444a1-34f5-4cf5-ac22-7469b7be466d}, !- Handle
   189.1-2009 - Office - Vending - CZ1-3 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {4a0f0aee-7d95-4341-825c-8f70d1309b6b}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ1-3, !- Name
-  ,                                       !- Default Construction Set Name
-  {39feaf8a-6d16-4e68-9b8c-db2038aff03f}, !- Default Schedule Set Name
-  {6fc91438-7cba-42dc-a37d-48434d3c06ca}, !- Group Rendering Name
-  {b1c52cb5-3326-4b43-a12f-f30cb1ac3119}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  WholeBuilding - Lg Office;              !- Standards Space Type
 
 OS:Rendering:Color,
   {6fc91438-7cba-42dc-a37d-48434d3c06ca}, !- Handle
@@ -2242,34 +1204,6 @@ OS:Rendering:Color,
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {39feaf8a-6d16-4e68-9b8c-db2038aff03f}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {ee654552-7290-4128-a647-073eff68ebb6}, !- Number of People Schedule Name
-  {264acba7-523a-484e-8e51-ae85870ba167}, !- People Activity Level Schedule Name
-  {3ce9efa4-e219-47f8-a14a-7affd9c11d70}, !- Lighting Schedule Name
-  {6197bef3-80c6-4043-b8a4-b9cd96652248}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {e0eb0ae2-9b39-46b2-b9f9-f7879620c44e}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {58b2159f-d857-497e-ae6a-2e8bd3520ef8}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  9.68751937503875,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {63218795-4f24-43ea-9e63-a6d83e1e86a3}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ1-3 Lights, !- Name
-  {58b2159f-d857-497e-ae6a-2e8bd3520ef8}, !- Lights Definition Name
-  {4a0f0aee-7d95-4341-825c-8f70d1309b6b}; !- Space or SpaceType Name
 
 OS:Schedule:Ruleset,
   {3ce9efa4-e219-47f8-a14a-7affd9c11d70}, ! Handle
@@ -2417,21 +1351,6 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {2e56af89-445a-4423-b5f8-13463d65edc8}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0538195520835486,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {4615604a-bd1a-474d-91be-9f075c13bd9a}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ1-3 People, !- Name
-  {2e56af89-445a-4423-b5f8-13463d65edc8}, !- People Definition Name
-  {4a0f0aee-7d95-4341-825c-8f70d1309b6b}; !- Space or SpaceType Name
-
 OS:Schedule:Ruleset,
   {ee654552-7290-4128-a647-073eff68ebb6}, ! Handle
   Large Office Bldg Occ,                  ! Name
@@ -2570,14 +1489,6 @@ OS:Schedule:Day,
   0,                                      ! Minute 5
   0;                                      ! Value Until Time 5
 
-OS:Schedule:Ruleset,
-  {264acba7-523a-484e-8e51-ae85870ba167}, ! Handle
-  Large Office Activity,                  ! Name
-  {d29d6f61-dbb6-43a0-8e80-994bfb4a73b2}, ! Schedule Type Limits Name
-  {0a6d9e60-3fca-4618-b0de-820e8f6767da}, ! Default Day Schedule Name
-  {642af5d3-2b0f-4b01-95b7-7698f50934d0}, ! Summer Design Day Schedule Name
-  {5490c47e-82ae-4901-8434-0b12bb9436ba}; ! Winter Design Day Schedule Name
-
 OS:ScheduleTypeLimits,
   {d29d6f61-dbb6-43a0-8e80-994bfb4a73b2}, !- Handle
   ActivityLevel 5,                        !- Name
@@ -2585,48 +1496,6 @@ OS:ScheduleTypeLimits,
   ,                                       !- Upper Limit Value {BasedOnField A4}
   Continuous,                             !- Numeric Type
   ActivityLevel;                          !- Unit Type
-
-OS:Schedule:Day,
-  {0a6d9e60-3fca-4618-b0de-820e8f6767da}, ! Handle
-  Large Office Activity Default Schedule, ! Name
-  {d29d6f61-dbb6-43a0-8e80-994bfb4a73b2}, ! Schedule Type Limits Name
-  ,                                       ! Interpolate to Timestep
-  24,                                     !- Hour 1
-  0,                                      !- Minute 1
-  120;                                    !- Value Until Time 1
-
-OS:Schedule:Day,
-  {642af5d3-2b0f-4b01-95b7-7698f50934d0}, ! Handle
-  Large Office Activity Summer Design Day, ! Name
-  {d29d6f61-dbb6-43a0-8e80-994bfb4a73b2}, ! Schedule Type Limits Name
-  ,                                       ! Interpolate to Timestep
-  24,                                     ! Hour 1
-  0,                                      ! Minute 1
-  120;                                    ! Value Until Time 1
-
-OS:Schedule:Day,
-  {5490c47e-82ae-4901-8434-0b12bb9436ba}, ! Handle
-  Large Office Activity Winter Design Day, ! Name
-  {d29d6f61-dbb6-43a0-8e80-994bfb4a73b2}, ! Schedule Type Limits Name
-  ,                                       ! Interpolate to Timestep
-  24,                                     ! Hour 1
-  0,                                      ! Minute 1
-  120;                                    ! Value Until Time 1
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {90014069-9853-4f75-becd-f17e7166df17}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ1-3 Infiltration, !- Name
-  {4a0f0aee-7d95-4341-825c-8f70d1309b6b}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
 
 OS:Schedule:Ruleset,
   {e0eb0ae2-9b39-46b2-b9f9-f7879620c44e}, ! Handle
@@ -2744,20 +1613,6 @@ OS:Schedule:Day,
   24,                                     ! Hour 3
   0,                                      ! Minute 3
   1;                                      ! Value Until Time 3
-
-OS:ElectricEquipment:Definition,
-  {148a4383-6613-4cb0-810d-92a639475c5c}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  5.81251412763851,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {896f52d4-b30e-46c3-b809-17a91eb06105}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ1-3 Electric Equipment, !- Name
-  {148a4383-6613-4cb0-810d-92a639475c5c}, !- Electric Equipment Definition Name
-  {4a0f0aee-7d95-4341-825c-8f70d1309b6b}; !- Space or SpaceType Name
 
 OS:Schedule:Ruleset,
   {6197bef3-80c6-4043-b8a4-b9cd96652248}, ! Handle
@@ -3123,50 +1978,12 @@ OS:Schedule:Day,
   0,                                      ! Minute 3
   26.699999999999999;                     ! Value Until Time 3
 
-OS:SpaceType,
-  {f1a5c162-f322-4c79-ba15-e43020514289}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ1-3, !- Name
-  ,                                       !- Default Construction Set Name
-  {f97da1fb-3578-4a67-9933-d2891cb549b6}, !- Default Schedule Set Name
-  {03e06c9d-a4bc-49de-952a-4329faa7fb71}, !- Group Rendering Name
-  {8f13e24f-0968-430b-82b1-c5e41da9fafa}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  WholeBuilding - Md Office;              !- Standards Space Type
-
 OS:Rendering:Color,
   {03e06c9d-a4bc-49de-952a-4329faa7fb71}, !- Handle
   Rendering Color 15,                     !- Name
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {f97da1fb-3578-4a67-9933-d2891cb549b6}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {c46af6b1-d997-440b-a480-2b785127791c}, !- Number of People Schedule Name
-  {4401923f-7369-4704-af97-5f02eccc07c4}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {e7df833e-4db6-469d-ad96-14b52ff0ceef}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {4b35ab56-cec3-45c0-bd82-7c7c88e72873}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {813e77fb-5ac1-47f6-a5e0-d9a9cd3db4a9}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  9.68751937503875,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {a5f0d2c1-e014-479a-8f1b-3ebac3e265e4}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ1-3 Lights, !- Name
-  {813e77fb-5ac1-47f6-a5e0-d9a9cd3db4a9}, !- Lights Definition Name
-  {f1a5c162-f322-4c79-ba15-e43020514289}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {8f13e24f-0968-430b-82b1-c5e41da9fafa}, !- Handle
@@ -3177,21 +1994,6 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Rate {m3/s}
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
-
-OS:People:Definition,
-  {d2de25c6-7190-4247-bdb6-aa1580eb569f}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0538195520835486,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {58a62980-ba6f-4bad-9e5d-fdacc8096f52}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ1-3 People, !- Name
-  {d2de25c6-7190-4247-bdb6-aa1580eb569f}, !- People Definition Name
-  {f1a5c162-f322-4c79-ba15-e43020514289}; !- Space or SpaceType Name
 
 OS:Schedule:Ruleset,
   {c46af6b1-d997-440b-a480-2b785127791c}, ! Handle
@@ -3331,14 +2133,6 @@ OS:Schedule:Day,
   0,                                      ! Minute 5
   0;                                      ! Value Until Time 5
 
-OS:Schedule:Ruleset,
-  {4401923f-7369-4704-af97-5f02eccc07c4}, ! Handle
-  Medium Office Activity,                 ! Name
-  {95269861-8fab-46f9-aa04-a6e9bad28f6a}, ! Schedule Type Limits Name
-  {bb81c5f0-bf9a-4988-98c4-eb4a990d7a88}, ! Default Day Schedule Name
-  {f3b095b2-bfff-494c-896b-85a436510b0b}, ! Summer Design Day Schedule Name
-  {d26b3326-27cf-44ae-b92e-698b3492b9c3}; ! Winter Design Day Schedule Name
-
 OS:ScheduleTypeLimits,
   {95269861-8fab-46f9-aa04-a6e9bad28f6a}, !- Handle
   ActivityLevel 13,                       !- Name
@@ -3346,48 +2140,6 @@ OS:ScheduleTypeLimits,
   ,                                       !- Upper Limit Value {BasedOnField A4}
   Continuous,                             !- Numeric Type
   ActivityLevel;                          !- Unit Type
-
-OS:Schedule:Day,
-  {bb81c5f0-bf9a-4988-98c4-eb4a990d7a88}, ! Handle
-  Medium Office Activity Default Schedule, ! Name
-  {95269861-8fab-46f9-aa04-a6e9bad28f6a}, ! Schedule Type Limits Name
-  ,                                       ! Interpolate to Timestep
-  24,                                     !- Hour 1
-  0,                                      !- Minute 1
-  120;                                    !- Value Until Time 1
-
-OS:Schedule:Day,
-  {f3b095b2-bfff-494c-896b-85a436510b0b}, ! Handle
-  Medium Office Activity Summer Design Day, ! Name
-  {95269861-8fab-46f9-aa04-a6e9bad28f6a}, ! Schedule Type Limits Name
-  ,                                       ! Interpolate to Timestep
-  24,                                     ! Hour 1
-  0,                                      ! Minute 1
-  120;                                    ! Value Until Time 1
-
-OS:Schedule:Day,
-  {d26b3326-27cf-44ae-b92e-698b3492b9c3}, ! Handle
-  Medium Office Activity Winter Design Day, ! Name
-  {95269861-8fab-46f9-aa04-a6e9bad28f6a}, ! Schedule Type Limits Name
-  ,                                       ! Interpolate to Timestep
-  24,                                     ! Hour 1
-  0,                                      ! Minute 1
-  120;                                    ! Value Until Time 1
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {eeedf250-2cf8-460c-88a9-6a3cf6835b8d}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ1-3 Infiltration, !- Name
-  {f1a5c162-f322-4c79-ba15-e43020514289}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
 
 OS:Schedule:Ruleset,
   {4b35ab56-cec3-45c0-bd82-7c7c88e72873}, ! Handle
@@ -3505,20 +2257,6 @@ OS:Schedule:Day,
   24,                                     ! Hour 3
   0,                                      ! Minute 3
   1;                                      ! Value Until Time 3
-
-OS:ElectricEquipment:Definition,
-  {08d105c1-a5c4-43eb-872f-8bd123ea9720}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  5.81251162502325,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {92bed684-e409-4e09-8f9b-036a79bdc3c6}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ1-3 Electric Equipment, !- Name
-  {08d105c1-a5c4-43eb-872f-8bd123ea9720}, !- Electric Equipment Definition Name
-  {f1a5c162-f322-4c79-ba15-e43020514289}; !- Space or SpaceType Name
 
 OS:Schedule:Ruleset,
   {e7df833e-4db6-469d-ad96-14b52ff0ceef}, ! Handle
@@ -3652,50 +2390,12 @@ OS:ThermostatSetpoint:DualSetpoint,
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
 
-OS:SpaceType,
-  {e1cc070f-9032-474a-a692-fe55745caa04}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ1-3, !- Name
-  ,                                       !- Default Construction Set Name
-  {d32f1055-150c-4db0-85e7-cd8d80091a97}, !- Default Schedule Set Name
-  {acb4804a-6b98-49bc-8337-c128f3c2ea30}, !- Group Rendering Name
-  {6410e886-4201-485e-a1a7-5fa1c8b6bdf4}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  WholeBuilding - Sm Office;              !- Standards Space Type
-
 OS:Rendering:Color,
   {acb4804a-6b98-49bc-8337-c128f3c2ea30}, !- Handle
   Rendering Color 16,                     !- Name
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {d32f1055-150c-4db0-85e7-cd8d80091a97}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ1-3 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {7db91015-b01f-42c8-b02c-a13d4ed39198}, !- Number of People Schedule Name
-  {67a55331-2096-4c9b-981a-b63f113d0dd9}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {a51b8fe3-0466-410b-a880-21be07500a52}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {cb7cb752-a33a-400e-97f3-836bf023796e}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {71df8542-c73a-4a75-96b3-2049ec201c3b}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ1-3 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  9.68751937503875,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {453c5932-0aee-459f-ac1d-0563be79832e}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ1-3 Lights, !- Name
-  {71df8542-c73a-4a75-96b3-2049ec201c3b}, !- Lights Definition Name
-  {e1cc070f-9032-474a-a692-fe55745caa04}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {6410e886-4201-485e-a1a7-5fa1c8b6bdf4}, !- Handle
@@ -3706,21 +2406,6 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Rate {m3/s}
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
-
-OS:People:Definition,
-  {7accfcbc-2a91-4f56-8250-c9c73d4bce14}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ1-3 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0538195520835486,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {d10bfc0d-d823-4de2-8ad6-a13acf3eb5e9}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ1-3 People, !- Name
-  {7accfcbc-2a91-4f56-8250-c9c73d4bce14}, !- People Definition Name
-  {e1cc070f-9032-474a-a692-fe55745caa04}; !- Space or SpaceType Name
 
 OS:Schedule:Ruleset,
   {7db91015-b01f-42c8-b02c-a13d4ed39198}, ! Handle
@@ -3857,14 +2542,6 @@ OS:Schedule:Day,
   0,                                      ! Minute 5
   0;                                      ! Value Until Time 5
 
-OS:Schedule:Ruleset,
-  {67a55331-2096-4c9b-981a-b63f113d0dd9}, ! Handle
-  Small Office Activity,                  ! Name
-  {ab8bd902-d0dc-41a0-936a-32afa4684057}, ! Schedule Type Limits Name
-  {12ff5327-86b6-42bd-9d53-941110babe19}, ! Default Day Schedule Name
-  {be5e67a8-5b36-4ac3-9813-2ebd31fec570}, ! Summer Design Day Schedule Name
-  {bae73b41-e18c-4183-82f3-dc5b3daf6b5a}; ! Winter Design Day Schedule Name
-
 OS:ScheduleTypeLimits,
   {ab8bd902-d0dc-41a0-936a-32afa4684057}, !- Handle
   ActivityLevel 12,                       !- Name
@@ -3872,48 +2549,6 @@ OS:ScheduleTypeLimits,
   ,                                       !- Upper Limit Value {BasedOnField A4}
   Continuous,                             !- Numeric Type
   ActivityLevel;                          !- Unit Type
-
-OS:Schedule:Day,
-  {12ff5327-86b6-42bd-9d53-941110babe19}, ! Handle
-  Small Office Activity Default Schedule, ! Name
-  {ab8bd902-d0dc-41a0-936a-32afa4684057}, ! Schedule Type Limits Name
-  ,                                       ! Interpolate to Timestep
-  24,                                     !- Hour 1
-  0,                                      !- Minute 1
-  120;                                    !- Value Until Time 1
-
-OS:Schedule:Day,
-  {be5e67a8-5b36-4ac3-9813-2ebd31fec570}, ! Handle
-  Small Office Activity Summer Design Day, ! Name
-  {ab8bd902-d0dc-41a0-936a-32afa4684057}, ! Schedule Type Limits Name
-  ,                                       ! Interpolate to Timestep
-  24,                                     ! Hour 1
-  0,                                      ! Minute 1
-  120;                                    ! Value Until Time 1
-
-OS:Schedule:Day,
-  {bae73b41-e18c-4183-82f3-dc5b3daf6b5a}, ! Handle
-  Small Office Activity Winter Design Day, ! Name
-  {ab8bd902-d0dc-41a0-936a-32afa4684057}, ! Schedule Type Limits Name
-  ,                                       ! Interpolate to Timestep
-  24,                                     ! Hour 1
-  0,                                      ! Minute 1
-  120;                                    ! Value Until Time 1
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {1e027a7c-c27f-4a3d-8cdf-0828601a4f05}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ1-3 Infiltration, !- Name
-  {e1cc070f-9032-474a-a692-fe55745caa04}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.00030226,                             !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
 
 OS:Schedule:Ruleset,
   {cb7cb752-a33a-400e-97f3-836bf023796e}, ! Handle
@@ -4031,20 +2666,6 @@ OS:Schedule:Day,
   24,                                     ! Hour 3
   0,                                      ! Minute 3
   1;                                      ! Value Until Time 3
-
-OS:ElectricEquipment:Definition,
-  {39f1a8d8-4466-4a00-8eb7-ffec43b67ef7}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ1-3 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  5.81251162502325,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {37b7d99c-9391-4952-b185-a511e62b7beb}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ1-3 Electric Equipment, !- Name
-  {39f1a8d8-4466-4a00-8eb7-ffec43b67ef7}, !- Electric Equipment Definition Name
-  {e1cc070f-9032-474a-a692-fe55745caa04}; !- Space or SpaceType Name
 
 OS:Schedule:Ruleset,
   {a51b8fe3-0466-410b-a880-21be07500a52}, ! Handle
@@ -4404,50 +3025,12 @@ OS:Schedule:Day,
   0,                                      ! Minute 3
   26.699999999999999;                     ! Value Until Time 3
 
-OS:SpaceType,
-  {6fcac478-58b9-4f2f-ab61-2fdf78ed207a}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ4-8, !- Name
-  ,                                       !- Default Construction Set Name
-  {0b0d7d0e-8e0c-4d73-bbd0-4d262ac73220}, !- Default Schedule Set Name
-  {99b31bfd-0d42-45f4-a0d8-d4817aca24ae}, !- Group Rendering Name
-  {f6d5ea3e-58cf-41e5-81fb-02117411a981}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  BreakRoom;                              !- Standards Space Type
-
 OS:Rendering:Color,
   {99b31bfd-0d42-45f4-a0d8-d4817aca24ae}, !- Handle
   Rendering Color 17,                     !- Name
   230,                                    !- Rendering Red Value
   157,                                    !- Rendering Green Value
   120;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {0b0d7d0e-8e0c-4d73-bbd0-4d262ac73220}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {9d2a2115-85c5-438b-b32c-a4a858d8161a}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  11.6250232500465,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {4a230733-41f5-4ca6-96e0-5e44748f7df4}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ4-8 Lights, !- Name
-  {9d2a2115-85c5-438b-b32c-a4a858d8161a}, !- Lights Definition Name
-  {6fcac478-58b9-4f2f-ab61-2fdf78ed207a}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {f6d5ea3e-58cf-41e5-81fb-02117411a981}, !- Handle
@@ -4459,65 +3042,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {23d096cd-2bb1-423d-b1c8-baf5526ef2a6}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.538195520835486,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {5a10a8e5-74eb-41b6-8300-8c614f3cd681}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ4-8 People, !- Name
-  {23d096cd-2bb1-423d-b1c8-baf5526ef2a6}, !- People Definition Name
-  {6fcac478-58b9-4f2f-ab61-2fdf78ed207a}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {6eb84b2f-973d-476e-b524-53b69c751752}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ4-8 Infiltration, !- Name
-  {6fcac478-58b9-4f2f-ab61-2fdf78ed207a}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {5b57df41-243c-46ff-9790-d9497bd8edf0}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  48.0070404585254,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {e641d016-e7d6-4890-957c-3de2b21a699a}, !- Handle
-  189.1-2009 - Office - BreakRoom - CZ4-8 Electric Equipment, !- Name
-  {5b57df41-243c-46ff-9790-d9497bd8edf0}, !- Electric Equipment Definition Name
-  {6fcac478-58b9-4f2f-ab61-2fdf78ed207a}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {92dbe6d3-c9b9-43fc-90c3-a06b5ec93169}, !- Handle
   189.1-2009 - Office - BreakRoom - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {ac0a78a9-f73e-43b0-b8ae-e687babd2992}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ4-8, !- Name
-  ,                                       !- Default Construction Set Name
-  {45d37156-65d2-4044-abc0-329c2491e0be}, !- Default Schedule Set Name
-  {6dc82c65-0965-48c5-9394-1f57bef18075}, !- Group Rendering Name
-  {2cbf38dd-78ec-43cf-9455-8dba2eee1857}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  ClosedOffice;                           !- Standards Space Type
 
 OS:Rendering:Color,
   {6dc82c65-0965-48c5-9394-1f57bef18075}, !- Handle
@@ -4525,34 +3054,6 @@ OS:Rendering:Color,
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {45d37156-65d2-4044-abc0-329c2491e0be}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {3f7fc9e5-6ce2-4b91-9fc6-85d1867c2216}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {f855eb4f-a401-4c05-9693-85547aab5919}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  10.6562713125426,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {e6b87a14-1e18-49c7-85c2-84f072c938b2}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ4-8 Lights, !- Name
-  {f855eb4f-a401-4c05-9693-85547aab5919}, !- Lights Definition Name
-  {ac0a78a9-f73e-43b0-b8ae-e687babd2992}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {2cbf38dd-78ec-43cf-9455-8dba2eee1857}, !- Handle
@@ -4564,65 +3065,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {2a7bd42c-841d-4013-b4e7-019f52823262}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0511285744793712,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {283ae026-2477-4529-bb38-02c7e6065076}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ4-8 People, !- Name
-  {2a7bd42c-841d-4013-b4e7-019f52823262}, !- People Definition Name
-  {ac0a78a9-f73e-43b0-b8ae-e687babd2992}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {b655059c-3ce9-4b49-a0db-160442a03540}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ4-8 Infiltration, !- Name
-  {ac0a78a9-f73e-43b0-b8ae-e687babd2992}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {56de10a1-c355-43cc-8c70-789938bd1248}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  6.88890266669422,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {0f379c88-6f89-4030-bc79-090ef24b986e}, !- Handle
-  189.1-2009 - Office - ClosedOffice - CZ4-8 Electric Equipment, !- Name
-  {56de10a1-c355-43cc-8c70-789938bd1248}, !- Electric Equipment Definition Name
-  {ac0a78a9-f73e-43b0-b8ae-e687babd2992}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {6b3eff15-c2f8-4f87-9fe3-6f7c3004ea5f}, !- Handle
   189.1-2009 - Office - ClosedOffice - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {b9bdae74-1b30-442c-a7ed-69d06b515457}, !- Handle
-  189.1-2009 - Office - Conference - CZ4-8, !- Name
-  ,                                       !- Default Construction Set Name
-  {e6c39dce-80ca-4ed4-a781-b5e18baff696}, !- Default Schedule Set Name
-  {202e2808-fe0a-49ec-8437-4c794472a9a0}, !- Group Rendering Name
-  {b8c9a3c5-53fb-4331-9614-87a518236f35}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Conference;                             !- Standards Space Type
 
 OS:Rendering:Color,
   {202e2808-fe0a-49ec-8437-4c794472a9a0}, !- Handle
@@ -4630,34 +3077,6 @@ OS:Rendering:Color,
   230,                                    !- Rendering Red Value
   196,                                    !- Rendering Green Value
   120;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {e6c39dce-80ca-4ed4-a781-b5e18baff696}, !- Handle
-  189.1-2009 - Office - Conference - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {bcc996df-46dd-45ba-abe0-69433df53594}, !- Handle
-  189.1-2009 - Office - Conference - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  12.5937751875504,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {86c2e905-536c-4838-bf48-8aa4aebef755}, !- Handle
-  189.1-2009 - Office - Conference - CZ4-8 Lights, !- Name
-  {bcc996df-46dd-45ba-abe0-69433df53594}, !- Lights Definition Name
-  {b9bdae74-1b30-442c-a7ed-69d06b515457}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {b8c9a3c5-53fb-4331-9614-87a518236f35}, !- Handle
@@ -4669,65 +3088,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {f07defcd-cf7a-424b-a3f5-c1672133261e}, !- Handle
-  189.1-2009 - Office - Conference - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.538195520835486,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {884b2aa3-62fe-4d6a-b8ec-c19497fc7da8}, !- Handle
-  189.1-2009 - Office - Conference - CZ4-8 People, !- Name
-  {f07defcd-cf7a-424b-a3f5-c1672133261e}, !- People Definition Name
-  {b9bdae74-1b30-442c-a7ed-69d06b515457}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {23919b1f-4940-4b68-b1a0-5e68c2d5b78d}, !- Handle
-  189.1-2009 - Office - Conference - CZ4-8 Infiltration, !- Name
-  {b9bdae74-1b30-442c-a7ed-69d06b515457}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {aca91e63-a266-464d-b600-e89b347c9d95}, !- Handle
-  189.1-2009 - Office - Conference - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  3.9826468541826,                        !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {7ecb1b95-ffa4-4c84-b1e4-cf8c033ce8f7}, !- Handle
-  189.1-2009 - Office - Conference - CZ4-8 Electric Equipment, !- Name
-  {aca91e63-a266-464d-b600-e89b347c9d95}, !- Electric Equipment Definition Name
-  {b9bdae74-1b30-442c-a7ed-69d06b515457}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {541fa24b-ddf2-4edf-83d9-2bed06917add}, !- Handle
   189.1-2009 - Office - Conference - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {7150cb23-2c41-4569-8cb3-ed7c1cd4f2f7}, !- Handle
-  189.1-2009 - Office - Corridor - CZ4-8, !- Name
-  ,                                       !- Default Construction Set Name
-  {666e2765-a8cc-4272-9029-54b416bb2610}, !- Default Schedule Set Name
-  {340eeae9-9587-4e04-b7fe-21214fa0042c}, !- Group Rendering Name
-  {fd69f378-0e94-4fdd-a231-f37cf315cc66}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Corridor;                               !- Standards Space Type
 
 OS:Rendering:Color,
   {340eeae9-9587-4e04-b7fe-21214fa0042c}, !- Handle
@@ -4735,34 +3100,6 @@ OS:Rendering:Color,
   169,                                    !- Rendering Red Value
   31,                                     !- Rendering Green Value
   31;                                     !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {666e2765-a8cc-4272-9029-54b416bb2610}, !- Handle
-  189.1-2009 - Office - Corridor - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {3f7fc9e5-6ce2-4b91-9fc6-85d1867c2216}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {a6e7a355-270c-45fb-9c56-5f4a3452110c}, !- Handle
-  189.1-2009 - Office - Corridor - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  4.84375968751938,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {fed0a7aa-9bc2-4d98-bc74-465b35a409d4}, !- Handle
-  189.1-2009 - Office - Corridor - CZ4-8 Lights, !- Name
-  {a6e7a355-270c-45fb-9c56-5f4a3452110c}, !- Lights Definition Name
-  {7150cb23-2c41-4569-8cb3-ed7c1cd4f2f7}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {fd69f378-0e94-4fdd-a231-f37cf315cc66}, !- Handle
@@ -4774,65 +3111,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {cb9b3da7-3eea-4d6e-9db1-01acf0825dcd}, !- Handle
-  189.1-2009 - Office - Corridor - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0107639104167097,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {42ce457e-2d95-4fe6-9cda-f5042dea1c96}, !- Handle
-  189.1-2009 - Office - Corridor - CZ4-8 People, !- Name
-  {cb9b3da7-3eea-4d6e-9db1-01acf0825dcd}, !- People Definition Name
-  {7150cb23-2c41-4569-8cb3-ed7c1cd4f2f7}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {ca37d410-b9c7-4e62-b5ca-b87627a332cc}, !- Handle
-  189.1-2009 - Office - Corridor - CZ4-8 Infiltration, !- Name
-  {7150cb23-2c41-4569-8cb3-ed7c1cd4f2f7}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {3c280509-8b4d-4af3-aac1-fa15404f8b6d}, !- Handle
-  189.1-2009 - Office - Corridor - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  1.72222566667356,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {01d044ce-7e19-4288-a75a-77fc975d40d4}, !- Handle
-  189.1-2009 - Office - Corridor - CZ4-8 Electric Equipment, !- Name
-  {3c280509-8b4d-4af3-aac1-fa15404f8b6d}, !- Electric Equipment Definition Name
-  {7150cb23-2c41-4569-8cb3-ed7c1cd4f2f7}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {3bdf0199-3196-4d00-9272-a3b137675d31}, !- Handle
   189.1-2009 - Office - Corridor - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {ae0eddf0-a1d4-45c0-89c1-4f32cd232444}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ4-8, !- Name
-  ,                                       !- Default Construction Set Name
-  {4390b43b-ded0-461f-b061-f042bc13f91f}, !- Default Schedule Set Name
-  {09cc0a44-bde3-4ae8-97d5-6973b620eb23}, !- Group Rendering Name
-  {1fbee130-5b8b-41c4-b2e5-a35b678e1a1c}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Elec/MechRoom;                          !- Standards Space Type
 
 OS:Rendering:Color,
   {09cc0a44-bde3-4ae8-97d5-6973b620eb23}, !- Handle
@@ -4840,34 +3123,6 @@ OS:Rendering:Color,
   41,                                     !- Rendering Red Value
   31,                                     !- Rendering Green Value
   169;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {4390b43b-ded0-461f-b061-f042bc13f91f}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  ,                                       !- Number of People Schedule Name
-  ,                                       !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {0d6e7075-d80b-44ae-9ee6-0b2ad52b1548}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  14.5312790625581,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {d0fd0a9a-f35d-4f92-b9b5-cc437f048b81}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ4-8 Lights, !- Name
-  {0d6e7075-d80b-44ae-9ee6-0b2ad52b1548}, !- Lights Definition Name
-  {ae0eddf0-a1d4-45c0-89c1-4f32cd232444}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {1fbee130-5b8b-41c4-b2e5-a35b678e1a1c}, !- Handle
@@ -4879,50 +3134,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:SpaceInfiltration:DesignFlowRate,
-  {5886568b-d637-4e9b-b7c1-0d6b0bcc8fc9}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ4-8 Infiltration, !- Name
-  {ae0eddf0-a1d4-45c0-89c1-4f32cd232444}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {08047a8f-2dc9-4514-aa3a-dcd71c961969}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  2.90625581251162,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {2d527502-0ea9-4d22-9420-1faee6f46df3}, !- Handle
-  189.1-2009 - Office - Elec/MechRoom - CZ4-8 Electric Equipment, !- Name
-  {08047a8f-2dc9-4514-aa3a-dcd71c961969}, !- Electric Equipment Definition Name
-  {ae0eddf0-a1d4-45c0-89c1-4f32cd232444}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {bc8bbc76-ab44-4992-ad1d-80d2dbc7e77e}, !- Handle
   189.1-2009 - Office - Elec/MechRoom - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {25788573-0369-4919-952e-9f4a8d287a07}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ4-8,  !- Name
-  ,                                       !- Default Construction Set Name
-  {a77ae8b7-4aa2-41f7-b5a6-8856ba6e1aa9}, !- Default Schedule Set Name
-  {03a758bb-e62a-48b9-97b4-e7c9725503de}, !- Group Rendering Name
-  {c78ecc49-33c1-4baa-8f4a-3a3d4e3253e7}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  IT_Room;                                !- Standards Space Type
 
 OS:Rendering:Color,
   {03a758bb-e62a-48b9-97b4-e7c9725503de}, !- Handle
@@ -4930,34 +3146,6 @@ OS:Rendering:Color,
   41,                                     !- Rendering Red Value
   31,                                     !- Rendering Green Value
   169;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {a77ae8b7-4aa2-41f7-b5a6-8856ba6e1aa9}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {b22a9e34-087b-427c-b758-a0124a25cdc5}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  10.6562713125426,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {9d45cbfa-f2ce-4490-bfe6-9ea2b0ef403d}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ4-8 Lights, !- Name
-  {b22a9e34-087b-427c-b758-a0124a25cdc5}, !- Lights Definition Name
-  {25788573-0369-4919-952e-9f4a8d287a07}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {c78ecc49-33c1-4baa-8f4a-3a3d4e3253e7}, !- Handle
@@ -4969,65 +3157,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {a0c943ca-3fd3-4a76-8558-4194a944b98d}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0538195520835486,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {0e12ef15-0acb-4a55-95a0-2260cf7ad1a8}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ4-8 People, !- Name
-  {a0c943ca-3fd3-4a76-8558-4194a944b98d}, !- People Definition Name
-  {25788573-0369-4919-952e-9f4a8d287a07}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {06f80535-6c1b-4be5-8e24-e2f246b425c8}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ4-8 Infiltration, !- Name
-  {25788573-0369-4919-952e-9f4a8d287a07}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {75c6e605-824f-4e54-8dd0-f27abb35f641}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  16.7917002500672,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {23c00582-f748-4c1b-916b-1fa5c7686d7d}, !- Handle
-  189.1-2009 - Office - IT_Room - CZ4-8 Electric Equipment, !- Name
-  {75c6e605-824f-4e54-8dd0-f27abb35f641}, !- Electric Equipment Definition Name
-  {25788573-0369-4919-952e-9f4a8d287a07}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {d067df76-cf76-4cf6-aa35-0cbb12b8656a}, !- Handle
   189.1-2009 - Office - IT_Room - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {12b0b8db-f33b-4234-a2c9-ba750ae671ef}, !- Handle
-  189.1-2009 - Office - Lobby - CZ4-8,    !- Name
-  ,                                       !- Default Construction Set Name
-  {69f043ea-7f0a-4f57-a9b9-d557929fc49e}, !- Default Schedule Set Name
-  {74dc8dad-959b-491c-a50a-9af6ecd0a669}, !- Group Rendering Name
-  {dbdfd940-1c36-4bd0-afb4-880a785c5e6f}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Lobby;                                  !- Standards Space Type
 
 OS:Rendering:Color,
   {74dc8dad-959b-491c-a50a-9af6ecd0a669}, !- Handle
@@ -5035,34 +3169,6 @@ OS:Rendering:Color,
   230,                                    !- Rendering Red Value
   157,                                    !- Rendering Green Value
   120;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {69f043ea-7f0a-4f57-a9b9-d557929fc49e}, !- Handle
-  189.1-2009 - Office - Lobby - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {f8e9e766-9250-4cfa-86f6-1216a4564dfb}, !- Handle
-  189.1-2009 - Office - Lobby - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  12.5937751875504,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {44ac18e1-7275-4b3a-b218-7e2e176f1a73}, !- Handle
-  189.1-2009 - Office - Lobby - CZ4-8 Lights, !- Name
-  {f8e9e766-9250-4cfa-86f6-1216a4564dfb}, !- Lights Definition Name
-  {12b0b8db-f33b-4234-a2c9-ba750ae671ef}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {dbdfd940-1c36-4bd0-afb4-880a785c5e6f}, !- Handle
@@ -5074,65 +3180,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {7e4b36df-78b6-45fb-a861-8e35ddce0df9}, !- Handle
-  189.1-2009 - Office - Lobby - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.107639104167097,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {d1894ae1-fe0a-4638-8df5-d20ee93f1533}, !- Handle
-  189.1-2009 - Office - Lobby - CZ4-8 People, !- Name
-  {7e4b36df-78b6-45fb-a861-8e35ddce0df9}, !- People Definition Name
-  {12b0b8db-f33b-4234-a2c9-ba750ae671ef}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {d815095f-6e93-44e7-9812-f55b6c2aef2e}, !- Handle
-  189.1-2009 - Office - Lobby - CZ4-8 Infiltration, !- Name
-  {12b0b8db-f33b-4234-a2c9-ba750ae671ef}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {e8a069db-d0db-4d2f-8265-790a7831bafa}, !- Handle
-  189.1-2009 - Office - Lobby - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  0.753473729169681,                      !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {24778cfb-5eee-4ddc-902b-a11bb0bfef66}, !- Handle
-  189.1-2009 - Office - Lobby - CZ4-8 Electric Equipment, !- Name
-  {e8a069db-d0db-4d2f-8265-790a7831bafa}, !- Electric Equipment Definition Name
-  {12b0b8db-f33b-4234-a2c9-ba750ae671ef}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {3fabcd0e-e1a5-4e00-9e23-9e19d5c555d9}, !- Handle
   189.1-2009 - Office - Lobby - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {ad9972e4-489e-404e-841e-c9bbd72d0111}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ4-8, !- Name
-  ,                                       !- Default Construction Set Name
-  {67cfc28b-9f66-4e18-8b2c-25a2ff33fd11}, !- Default Schedule Set Name
-  {ede0a72d-692f-411e-898f-ccb1f783c262}, !- Group Rendering Name
-  {f4a649b7-7f7c-4bc5-9b02-e4e1aa4803e9}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  OpenOffice;                             !- Standards Space Type
 
 OS:Rendering:Color,
   {ede0a72d-692f-411e-898f-ccb1f783c262}, !- Handle
@@ -5140,34 +3192,6 @@ OS:Rendering:Color,
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {67cfc28b-9f66-4e18-8b2c-25a2ff33fd11}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {3f7fc9e5-6ce2-4b91-9fc6-85d1867c2216}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {18a52544-7daa-4972-9e7f-9e27c5a4cd66}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  10.6562713125426,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {a396c5cc-c22f-42c9-be8e-af3d54d54456}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ4-8 Lights, !- Name
-  {18a52544-7daa-4972-9e7f-9e27c5a4cd66}, !- Lights Definition Name
-  {ad9972e4-489e-404e-841e-c9bbd72d0111}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {f4a649b7-7f7c-4bc5-9b02-e4e1aa4803e9}, !- Handle
@@ -5179,65 +3203,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {22b512ed-ce73-4779-9d6d-34a5d817a868}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.056510529687726,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {6b5422a3-490d-4e08-a37c-480ec55d22f6}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ4-8 People, !- Name
-  {22b512ed-ce73-4779-9d6d-34a5d817a868}, !- People Definition Name
-  {ad9972e4-489e-404e-841e-c9bbd72d0111}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {9f99f28a-55da-49b7-9354-17ccfd3b33e0}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ4-8 Infiltration, !- Name
-  {ad9972e4-489e-404e-841e-c9bbd72d0111}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {95fc5eef-d77d-4616-917f-974b5dabab66}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  7.6423763958639,                        !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {8470e1c3-c0bc-4712-81bc-3382735de5cb}, !- Handle
-  189.1-2009 - Office - OpenOffice - CZ4-8 Electric Equipment, !- Name
-  {95fc5eef-d77d-4616-917f-974b5dabab66}, !- Electric Equipment Definition Name
-  {ad9972e4-489e-404e-841e-c9bbd72d0111}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {847f379b-0ddb-4308-a125-44b06cceb0c0}, !- Handle
   189.1-2009 - Office - OpenOffice - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {af24e503-88ef-4f50-95c1-1d393388f2d4}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ4-8, !- Name
-  ,                                       !- Default Construction Set Name
-  {01dc8eb4-a4fa-4aaf-8d75-b7cfd75648a4}, !- Default Schedule Set Name
-  {b7fe6f07-3ac4-4ca1-9186-5c7889d7b3da}, !- Group Rendering Name
-  {6c78e848-e562-4461-b538-4e3e3c4e848c}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  PrintRoom;                              !- Standards Space Type
 
 OS:Rendering:Color,
   {b7fe6f07-3ac4-4ca1-9186-5c7889d7b3da}, !- Handle
@@ -5245,34 +3215,6 @@ OS:Rendering:Color,
   41,                                     !- Rendering Red Value
   31,                                     !- Rendering Green Value
   169;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {01dc8eb4-a4fa-4aaf-8d75-b7cfd75648a4}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {abbc193f-2c53-49ff-8e03-589edefce026}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  10.6562713125426,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {c7396387-ee02-4cbd-bb73-db5af92230bf}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ4-8 Lights, !- Name
-  {abbc193f-2c53-49ff-8e03-589edefce026}, !- Lights Definition Name
-  {af24e503-88ef-4f50-95c1-1d393388f2d4}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {6c78e848-e562-4461-b538-4e3e3c4e848c}, !- Handle
@@ -5284,65 +3226,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {4cbb660a-8380-44eb-bc35-245838f929e8}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.107639104167097,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {89b76b4c-73be-47ed-9bf0-d29a5d09beee}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ4-8 People, !- Name
-  {4cbb660a-8380-44eb-bc35-245838f929e8}, !- People Definition Name
-  {af24e503-88ef-4f50-95c1-1d393388f2d4}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {68e0ada3-23ed-42e8-881a-ad68ae78ba59}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ4-8 Infiltration, !- Name
-  {af24e503-88ef-4f50-95c1-1d393388f2d4}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {cd6a7fd7-b08c-4cbb-9ce5-8ddc886a6124}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  30.0313100626201,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {47ea6833-7452-423c-b11a-cdcdc6e894f7}, !- Handle
-  189.1-2009 - Office - PrintRoom - CZ4-8 Electric Equipment, !- Name
-  {cd6a7fd7-b08c-4cbb-9ce5-8ddc886a6124}, !- Electric Equipment Definition Name
-  {af24e503-88ef-4f50-95c1-1d393388f2d4}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {9a24efdb-aaf9-4caf-8ef9-e063f557395c}, !- Handle
   189.1-2009 - Office - PrintRoom - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {8bff2199-45e8-4a71-b5fd-ede3fae4f6ff}, !- Handle
-  189.1-2009 - Office - Restroom - CZ4-8, !- Name
-  ,                                       !- Default Construction Set Name
-  {e66e0cc6-efb5-4211-818f-1431a0e70233}, !- Default Schedule Set Name
-  {719a1449-7853-4161-927b-bdb7f01806ed}, !- Group Rendering Name
-  {1aeb672d-5c17-4118-b3f0-dfbc58007e1f}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Restroom;                               !- Standards Space Type
 
 OS:Rendering:Color,
   {719a1449-7853-4161-927b-bdb7f01806ed}, !- Handle
@@ -5350,34 +3238,6 @@ OS:Rendering:Color,
   169,                                    !- Rendering Red Value
   169,                                    !- Rendering Green Value
   31;                                     !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {e66e0cc6-efb5-4211-818f-1431a0e70233}, !- Handle
-  189.1-2009 - Office - Restroom - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {d607f8dd-35e4-4a28-bcbe-31e09c118ae0}, !- Handle
-  189.1-2009 - Office - Restroom - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  8.71876743753488,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {369dc730-3d03-40c8-8ea1-7783c58a58ef}, !- Handle
-  189.1-2009 - Office - Restroom - CZ4-8 Lights, !- Name
-  {d607f8dd-35e4-4a28-bcbe-31e09c118ae0}, !- Lights Definition Name
-  {8bff2199-45e8-4a71-b5fd-ede3fae4f6ff}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {1aeb672d-5c17-4118-b3f0-dfbc58007e1f}, !- Handle
@@ -5389,65 +3249,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {8e492d6d-50ee-4026-a23a-6327d28aa1a3}, !- Handle
-  189.1-2009 - Office - Restroom - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.107639104167097,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {de991af8-6b18-4490-9be9-307feba43cd2}, !- Handle
-  189.1-2009 - Office - Restroom - CZ4-8 People, !- Name
-  {8e492d6d-50ee-4026-a23a-6327d28aa1a3}, !- People Definition Name
-  {8bff2199-45e8-4a71-b5fd-ede3fae4f6ff}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {efad6973-728f-404e-84ce-bf89300a55cd}, !- Handle
-  189.1-2009 - Office - Restroom - CZ4-8 Infiltration, !- Name
-  {8bff2199-45e8-4a71-b5fd-ede3fae4f6ff}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {c817a3b9-a026-4a06-82cf-32d30b4ef116}, !- Handle
-  189.1-2009 - Office - Restroom - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  0.753473729169681,                      !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {36815876-83bd-4fa7-ad65-9cfc31a60c5d}, !- Handle
-  189.1-2009 - Office - Restroom - CZ4-8 Electric Equipment, !- Name
-  {c817a3b9-a026-4a06-82cf-32d30b4ef116}, !- Electric Equipment Definition Name
-  {8bff2199-45e8-4a71-b5fd-ede3fae4f6ff}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {ec97771e-4971-46b0-91e9-3785d44f364f}, !- Handle
   189.1-2009 - Office - Restroom - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {6cfd0d19-c82c-444b-b844-b898e9ccb38b}, !- Handle
-  189.1-2009 - Office - Stair - CZ4-8,    !- Name
-  ,                                       !- Default Construction Set Name
-  {1d7040c9-cc51-49e9-bced-99919b77079e}, !- Default Schedule Set Name
-  {6f557e2a-06b2-4e96-bd62-f7b1f6d0b22c}, !- Group Rendering Name
-  {06eb26bf-daae-4d7b-802f-f14f4973bffc}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Stair;                                  !- Standards Space Type
 
 OS:Rendering:Color,
   {6f557e2a-06b2-4e96-bd62-f7b1f6d0b22c}, !- Handle
@@ -5455,34 +3261,6 @@ OS:Rendering:Color,
   230,                                    !- Rendering Red Value
   157,                                    !- Rendering Green Value
   120;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {1d7040c9-cc51-49e9-bced-99919b77079e}, !- Handle
-  189.1-2009 - Office - Stair - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  ,                                       !- Number of People Schedule Name
-  ,                                       !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  ,                                       !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {2783b7ad-e79e-4709-93a0-76d9b15480cb}, !- Handle
-  189.1-2009 - Office - Stair - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  5.81251162502325,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {086e0aa7-9716-40a1-ad9a-9e539b32999b}, !- Handle
-  189.1-2009 - Office - Stair - CZ4-8 Lights, !- Name
-  {2783b7ad-e79e-4709-93a0-76d9b15480cb}, !- Lights Definition Name
-  {6cfd0d19-c82c-444b-b844-b898e9ccb38b}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {06eb26bf-daae-4d7b-802f-f14f4973bffc}, !- Handle
@@ -5494,36 +3272,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:SpaceInfiltration:DesignFlowRate,
-  {2584ae7a-711d-473c-96df-a3bb8f824179}, !- Handle
-  189.1-2009 - Office - Stair - CZ4-8 Infiltration, !- Name
-  {6cfd0d19-c82c-444b-b844-b898e9ccb38b}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
 OS:ThermostatSetpoint:DualSetpoint,
   {e23342a6-14bf-4244-a12e-b8f3f6c04563}, !- Handle
   189.1-2009 - Office - Stair - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {d0c52a2e-468a-4dde-bcb0-4952606e371d}, !- Handle
-  189.1-2009 - Office - Storage - CZ4-8,  !- Name
-  ,                                       !- Default Construction Set Name
-  {67b9c134-6af2-4034-8be9-99c918290f72}, !- Default Schedule Set Name
-  {e5e5daee-9c0f-481c-8a95-52831d130704}, !- Group Rendering Name
-  {891b5948-4e38-4554-a2f6-43f94ec5ae02}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Storage;                                !- Standards Space Type
 
 OS:Rendering:Color,
   {e5e5daee-9c0f-481c-8a95-52831d130704}, !- Handle
@@ -5531,34 +3284,6 @@ OS:Rendering:Color,
   120,                                    !- Rendering Red Value
   149,                                    !- Rendering Green Value
   230;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {67b9c134-6af2-4034-8be9-99c918290f72}, !- Handle
-  189.1-2009 - Office - Storage - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  ,                                       !- Number of People Schedule Name
-  ,                                       !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  ,                                       !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {a3530ea6-39e7-4538-9866-287cb9025bf1}, !- Handle
-  189.1-2009 - Office - Storage - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  7.750015500031,                         !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {f096f7ac-09c0-4f85-8905-690dca9182e1}, !- Handle
-  189.1-2009 - Office - Storage - CZ4-8 Lights, !- Name
-  {a3530ea6-39e7-4538-9866-287cb9025bf1}, !- Lights Definition Name
-  {d0c52a2e-468a-4dde-bcb0-4952606e371d}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {891b5948-4e38-4554-a2f6-43f94ec5ae02}, !- Handle
@@ -5570,36 +3295,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:SpaceInfiltration:DesignFlowRate,
-  {a7ac93a3-1fc2-4daa-82df-d9b5ba2a505e}, !- Handle
-  189.1-2009 - Office - Storage - CZ4-8 Infiltration, !- Name
-  {d0c52a2e-468a-4dde-bcb0-4952606e371d}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
 OS:ThermostatSetpoint:DualSetpoint,
   {6ae2b2b8-720b-4eaf-8895-80b1f0753cad}, !- Handle
   189.1-2009 - Office - Storage - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {badb4787-4e03-483b-a5d9-81df836430d2}, !- Handle
-  189.1-2009 - Office - Vending - CZ4-8,  !- Name
-  ,                                       !- Default Construction Set Name
-  {6dfba6f2-b96a-492d-b774-c4c720d68d2b}, !- Default Schedule Set Name
-  {76d6f7c9-7ceb-45e9-8a19-835ab84a952b}, !- Group Rendering Name
-  {0f1e8aef-c843-4ab6-b548-4c72c5fef55a}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  Vending;                                !- Standards Space Type
 
 OS:Rendering:Color,
   {76d6f7c9-7ceb-45e9-8a19-835ab84a952b}, !- Handle
@@ -5607,34 +3307,6 @@ OS:Rendering:Color,
   230,                                    !- Rendering Red Value
   157,                                    !- Rendering Green Value
   120;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {6dfba6f2-b96a-492d-b774-c4c720d68d2b}, !- Handle
-  189.1-2009 - Office - Vending - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {be0538a4-3720-422e-85be-2e617795d558}, !- Number of People Schedule Name
-  {2eaafb36-c8d9-471a-8f30-6e2188bd0fdb}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {d4102340-9627-4371-b8f6-a3790caa5373}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {5071fc8f-2a43-420e-b853-89de3fd548e0}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {d8b3e03e-2d32-4c27-b42a-dd840c225670}, !- Handle
-  189.1-2009 - Office - Vending - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  4.84375968751938,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {40216c47-a5be-4b81-9ebe-654734752677}, !- Handle
-  189.1-2009 - Office - Vending - CZ4-8 Lights, !- Name
-  {d8b3e03e-2d32-4c27-b42a-dd840c225670}, !- Lights Definition Name
-  {badb4787-4e03-483b-a5d9-81df836430d2}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {0f1e8aef-c843-4ab6-b548-4c72c5fef55a}, !- Handle
@@ -5646,65 +3318,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {f760ff07-53a3-4162-8890-9d0990ffc17f}, !- Handle
-  189.1-2009 - Office - Vending - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0107639104167097,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {281a8e29-5aab-4167-83d6-3d9fe2313cd8}, !- Handle
-  189.1-2009 - Office - Vending - CZ4-8 People, !- Name
-  {f760ff07-53a3-4162-8890-9d0990ffc17f}, !- People Definition Name
-  {badb4787-4e03-483b-a5d9-81df836430d2}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {b9453158-d790-4fab-b5ae-0e40fc0505ce}, !- Handle
-  189.1-2009 - Office - Vending - CZ4-8 Infiltration, !- Name
-  {badb4787-4e03-483b-a5d9-81df836430d2}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {bbac7541-8a86-4bd8-963a-8f9a28f77e61}, !- Handle
-  189.1-2009 - Office - Vending - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  41.4410551043324,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {eddb3a2b-a77b-4511-9cb5-b14f74a42d15}, !- Handle
-  189.1-2009 - Office - Vending - CZ4-8 Electric Equipment, !- Name
-  {bbac7541-8a86-4bd8-963a-8f9a28f77e61}, !- Electric Equipment Definition Name
-  {badb4787-4e03-483b-a5d9-81df836430d2}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {6c78a447-312c-4c28-b3aa-6da71f9cf8d3}, !- Handle
   189.1-2009 - Office - Vending - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {968bcc4c-fd98-438b-b61b-5f81da1d8956}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ4-8, !- Name
-  ,                                       !- Default Construction Set Name
-  {b9bfde29-315f-4eb8-bf9a-46a78dff4fac}, !- Default Schedule Set Name
-  {a76d196b-e761-4493-8631-b48b5e34c13c}, !- Group Rendering Name
-  {243951cc-1d54-4682-88de-92f00facb5d4}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  WholeBuilding - Lg Office;              !- Standards Space Type
 
 OS:Rendering:Color,
   {a76d196b-e761-4493-8631-b48b5e34c13c}, !- Handle
@@ -5712,34 +3330,6 @@ OS:Rendering:Color,
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {b9bfde29-315f-4eb8-bf9a-46a78dff4fac}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {ee654552-7290-4128-a647-073eff68ebb6}, !- Number of People Schedule Name
-  {264acba7-523a-484e-8e51-ae85870ba167}, !- People Activity Level Schedule Name
-  {3ce9efa4-e219-47f8-a14a-7affd9c11d70}, !- Lighting Schedule Name
-  {6197bef3-80c6-4043-b8a4-b9cd96652248}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {e0eb0ae2-9b39-46b2-b9f9-f7879620c44e}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {aa22ac73-8979-4986-b736-acbd0777b85c}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  9.68751937503875,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {b303525b-5f5d-4c4d-b9b8-65dd3f84b284}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ4-8 Lights, !- Name
-  {aa22ac73-8979-4986-b736-acbd0777b85c}, !- Lights Definition Name
-  {968bcc4c-fd98-438b-b61b-5f81da1d8956}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {243951cc-1d54-4682-88de-92f00facb5d4}, !- Handle
@@ -5751,65 +3341,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {9d7eb10a-2add-4a6a-a03e-056a6b1ae96b}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0538195520835486,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {03f6b94b-31fa-4bf8-8d80-15daaf19f543}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ4-8 People, !- Name
-  {9d7eb10a-2add-4a6a-a03e-056a6b1ae96b}, !- People Definition Name
-  {968bcc4c-fd98-438b-b61b-5f81da1d8956}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {78e4e1af-4f99-4e7e-a352-e31956fd36bf}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ4-8 Infiltration, !- Name
-  {968bcc4c-fd98-438b-b61b-5f81da1d8956}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {76753a4b-a553-4dd0-802b-90b0d1a1d966}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  5.81251412763851,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {2b65f72d-8ebb-4261-9f95-737986f7c212}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Lg Office - CZ4-8 Electric Equipment, !- Name
-  {76753a4b-a553-4dd0-802b-90b0d1a1d966}, !- Electric Equipment Definition Name
-  {968bcc4c-fd98-438b-b61b-5f81da1d8956}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {2829a6a3-d557-49c2-883a-6f3c5888d3dc}, !- Handle
   189.1-2009 - Office - WholeBuilding - Lg Office - CZ4-8 Thermostat, !- Name
   {e1c00ef5-f530-4453-a67b-ca54f0ae084f}, !- Heating Setpoint Temperature Schedule Name
   {205b7ba7-36bf-4caa-b304-f7da82550d15}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {e43c6330-829b-403f-9ef7-6b119710b699}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ4-8, !- Name
-  ,                                       !- Default Construction Set Name
-  {172a4339-c515-4808-9bf0-cd607a6b94aa}, !- Default Schedule Set Name
-  {d962ce0f-1f09-4520-8086-d251309638ff}, !- Group Rendering Name
-  {3157c89d-76b6-49f9-b874-c887b361d5a2}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  WholeBuilding - Md Office;              !- Standards Space Type
 
 OS:Rendering:Color,
   {d962ce0f-1f09-4520-8086-d251309638ff}, !- Handle
@@ -5817,34 +3353,6 @@ OS:Rendering:Color,
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {172a4339-c515-4808-9bf0-cd607a6b94aa}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {c46af6b1-d997-440b-a480-2b785127791c}, !- Number of People Schedule Name
-  {4401923f-7369-4704-af97-5f02eccc07c4}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {e7df833e-4db6-469d-ad96-14b52ff0ceef}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {4b35ab56-cec3-45c0-bd82-7c7c88e72873}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {dfa9825e-f1b4-468b-b1e4-5c934b4e8532}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  9.68751937503875,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {3f8dcdaf-a8d7-44f4-9031-8174616a0a98}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ4-8 Lights, !- Name
-  {dfa9825e-f1b4-468b-b1e4-5c934b4e8532}, !- Lights Definition Name
-  {e43c6330-829b-403f-9ef7-6b119710b699}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {3157c89d-76b6-49f9-b874-c887b361d5a2}, !- Handle
@@ -5856,65 +3364,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {795edcf3-25aa-491d-a678-58d2ca199b9b}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0538195520835486,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {3c49975f-c212-45d2-acc5-def109da8abd}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ4-8 People, !- Name
-  {795edcf3-25aa-491d-a678-58d2ca199b9b}, !- People Definition Name
-  {e43c6330-829b-403f-9ef7-6b119710b699}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {df024ec1-be72-4029-a6ce-a7a769ef9e4d}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ4-8 Infiltration, !- Name
-  {e43c6330-829b-403f-9ef7-6b119710b699}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {538b53f1-6409-45f7-aab7-31348cfbeb43}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  5.81251162502325,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {d39e66d5-58ca-4811-aff8-b5c8352cd6ce}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Md Office - CZ4-8 Electric Equipment, !- Name
-  {538b53f1-6409-45f7-aab7-31348cfbeb43}, !- Electric Equipment Definition Name
-  {e43c6330-829b-403f-9ef7-6b119710b699}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {125be356-b9df-4681-bbaa-d4c8cacde878}, !- Handle
   189.1-2009 - Office - WholeBuilding - Md Office - CZ4-8 Thermostat, !- Name
   {de733bb4-ab71-44d2-ab3a-a9b7c2a54774}, !- Heating Setpoint Temperature Schedule Name
   {e9bd9cb4-1124-4ccf-bf18-c5ad994faa55}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:SpaceType,
-  {af544d5a-8953-43ac-a2f2-b7ebb1e82e3a}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ4-8, !- Name
-  ,                                       !- Default Construction Set Name
-  {6784963e-ba4d-4175-87dd-b5831f929d87}, !- Default Schedule Set Name
-  {2fd05332-007b-4350-8fd3-4733ddca3f69}, !- Group Rendering Name
-  {22c007c1-ce62-40f2-8ab0-14c6a644baf2}, !- Design Specification Outdoor Air Object Name
-  Office,                                 !- Standards Building Type
-  WholeBuilding - Sm Office;              !- Standards Space Type
 
 OS:Rendering:Color,
   {2fd05332-007b-4350-8fd3-4733ddca3f69}, !- Handle
@@ -5922,34 +3376,6 @@ OS:Rendering:Color,
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {6784963e-ba4d-4175-87dd-b5831f929d87}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ4-8 Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {7db91015-b01f-42c8-b02c-a13d4ed39198}, !- Number of People Schedule Name
-  {67a55331-2096-4c9b-981a-b63f113d0dd9}, !- People Activity Level Schedule Name
-  {8a273f29-9e00-4685-a53d-4e9734fa3bef}, !- Lighting Schedule Name
-  {a51b8fe3-0466-410b-a880-21be07500a52}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {cb7cb752-a33a-400e-97f3-836bf023796e}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {c5b24316-59b0-434d-bbd1-d9024a57a7f8}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ4-8 Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  9.68751937503875,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {ee01b7ab-7d60-4088-8e4b-98136df7f22f}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ4-8 Lights, !- Name
-  {c5b24316-59b0-434d-bbd1-d9024a57a7f8}, !- Lights Definition Name
-  {af544d5a-8953-43ac-a2f2-b7ebb1e82e3a}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {22c007c1-ce62-40f2-8ab0-14c6a644baf2}, !- Handle
@@ -5961,75 +3387,11 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
-OS:People:Definition,
-  {c97216c8-66f4-458c-95f4-2ede85764002}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ4-8 People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.0538195520835486,                     !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {adf7594e-c7bc-44e3-8611-369b76c12e69}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ4-8 People, !- Name
-  {c97216c8-66f4-458c-95f4-2ede85764002}, !- People Definition Name
-  {af544d5a-8953-43ac-a2f2-b7ebb1e82e3a}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {181313d1-1146-4ec1-a3a2-fbbeceebc667}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ4-8 Infiltration, !- Name
-  {af544d5a-8953-43ac-a2f2-b7ebb1e82e3a}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.000226568,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {f65d6b4d-82ed-4ebf-bc2d-60f944322d6e}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ4-8 Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  5.81251162502325,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {b623d4f8-3118-49ac-bc0d-3c98d880b97c}, !- Handle
-  189.1-2009 - Office - WholeBuilding - Sm Office - CZ4-8 Electric Equipment, !- Name
-  {f65d6b4d-82ed-4ebf-bc2d-60f944322d6e}, !- Electric Equipment Definition Name
-  {af544d5a-8953-43ac-a2f2-b7ebb1e82e3a}; !- Space or SpaceType Name
-
 OS:ThermostatSetpoint:DualSetpoint,
   {7d3d60df-38bd-402a-8cc6-cb780862d808}, !- Handle
   189.1-2009 - Office - WholeBuilding - Sm Office - CZ4-8 Thermostat, !- Name
   {a8fc5971-56bf-485f-a8b6-fc00357a220a}, !- Heating Setpoint Temperature Schedule Name
   {8334d03b-d787-4c01-a860-2e97c980572e}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:DefaultConstructionSet,
-  {4526526b-2bc4-45b3-b597-da3d92ad09a1}, !- Handle
-  189.1-2009 - CZ1 - Office,              !- Name
-  {94698301-6b84-4a6f-8b78-75bca600fb17}, !- Default Exterior Surface Constructions Name
-  {30976b66-935b-4753-a4c5-4dde3dad9985}, !- Default Interior Surface Constructions Name
-  {a0baf7b0-7330-421a-9c8c-7addd1712d20}, !- Default Ground Contact Surface Constructions Name
-  {8c8dde84-fcf4-4c1e-ace0-a8bff3aee1ab}, !- Default Exterior SubSurface Constructions Name
-  {af21604d-d2d4-48d6-ad7c-2a2dbef9e849}, !- Default Interior SubSurface Constructions Name
-  {ead91c2f-4359-42f5-b36e-9a36c9253598}, !- Interior Partition Construction Name
-  ,                                       !- Space Shading Construction Name
-  ,                                       !- Building Shading Construction Name
-  ;                                       !- Site Shading Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {94698301-6b84-4a6f-8b78-75bca600fb17}, !- Handle
-  Default Surface Constructions 1,        !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {c79253de-386e-46f7-8631-b7bc0fd326fd}, !- Wall Construction Name
-  {94f9c7d5-7c2c-4130-9083-b2afb613c345}; !- Roof Ceiling Construction Name
 
 OS:Construction,
   {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Handle
@@ -6178,13 +3540,6 @@ OS:Material,
   0.6,                                    !- Solar Absorptance
   0.6;                                    !- Visible Absorptance
 
-OS:DefaultSurfaceConstructions,
-  {30976b66-935b-4753-a4c5-4dde3dad9985}, !- Handle
-  Default Surface Constructions 2,        !- Name
-  {4ee71df9-85c1-4a24-9be8-bee433f9e015}, !- Floor Construction Name
-  {7ea68359-ad75-4d6c-8862-e2965b9ee3ab}, !- Wall Construction Name
-  {edd9ecd3-4290-4d56-b5a9-ef02bf102418}; !- Roof Ceiling Construction Name
-
 OS:Construction,
   {4ee71df9-85c1-4a24-9be8-bee433f9e015}, !- Handle
   Interior Floor,                         !- Name
@@ -6272,25 +3627,6 @@ OS:StandardsInformation:Construction,
   {edd9ecd3-4290-4d56-b5a9-ef02bf102418}, !- Construction Name
   InteriorCeiling,                        !- Intended Surface Type
   ;                                       !- Standards Construction Type
-
-OS:DefaultSurfaceConstructions,
-  {a0baf7b0-7330-421a-9c8c-7addd1712d20}, !- Handle
-  Default Surface Constructions 3,        !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Wall Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}; !- Roof Ceiling Construction Name
-
-OS:DefaultSubSurfaceConstructions,
-  {8c8dde84-fcf4-4c1e-ace0-a8bff3aee1ab}, !- Handle
-  Default Sub Surface Constructions 1,    !- Name
-  {0644291c-bb2c-4d3e-8d12-d9bf784b59f3}, !- Fixed Window Construction Name
-  {0644291c-bb2c-4d3e-8d12-d9bf784b59f3}, !- Operable Window Construction Name
-  {f16a7fb7-d40d-43c5-9ad7-3bfe84654a03}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Tubular Daylight Dome Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}; !- Tubular Daylight Diffuser Construction Name
 
 OS:Construction,
   {0644291c-bb2c-4d3e-8d12-d9bf784b59f3}, !- Handle
@@ -6391,18 +3727,6 @@ OS:WindowMaterial:Glazing,
   1,                                      !- Dirt Correction Factor for Solar and Visible Transmittance
   No;                                     !- Solar Diffusing
 
-OS:DefaultSubSurfaceConstructions,
-  {af21604d-d2d4-48d6-ad7c-2a2dbef9e849}, !- Handle
-  Default Sub Surface Constructions 2,    !- Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Fixed Window Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Operable Window Construction Name
-  {ffeb525e-fabf-4359-8b2f-bec6d1975f7c}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  ,                                       !- Tubular Daylight Dome Construction Name
-  ;                                       !- Tubular Daylight Diffuser Construction Name
-
 OS:Construction,
   {ffeb525e-fabf-4359-8b2f-bec6d1975f7c}, !- Handle
   Interior Door,                          !- Name
@@ -6438,26 +3762,6 @@ OS:StandardsInformation:Construction,
   {ead91c2f-4359-42f5-b36e-9a36c9253598}, !- Construction Name
   InteriorPartition,                      !- Intended Surface Type
   ;                                       !- Standards Construction Type
-
-OS:DefaultConstructionSet,
-  {687d05db-8053-4a94-b114-53e0716a9896}, !- Handle
-  189.1-2009 - CZ2 - Office,              !- Name
-  {8edba1bd-b329-4c83-a9b8-09990e95b65e}, !- Default Exterior Surface Constructions Name
-  {e18c1749-b591-41fb-9e64-177679114054}, !- Default Interior Surface Constructions Name
-  {69098a8f-01d4-41f8-97e8-f3616bf95c30}, !- Default Ground Contact Surface Constructions Name
-  {26c0a2ac-6869-41a8-85e0-493990988654}, !- Default Exterior SubSurface Constructions Name
-  {31e1c75d-6ff4-480b-8189-458ca9a5f35c}, !- Default Interior SubSurface Constructions Name
-  {ead91c2f-4359-42f5-b36e-9a36c9253598}, !- Interior Partition Construction Name
-  ,                                       !- Space Shading Construction Name
-  ,                                       !- Building Shading Construction Name
-  ;                                       !- Site Shading Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {8edba1bd-b329-4c83-a9b8-09990e95b65e}, !- Handle
-  Default Surface Constructions 4,        !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {99407b2e-49f5-4dd2-a138-e5f57ad89854}, !- Wall Construction Name
-  {6e592600-ac13-4db1-bf26-a5a95984aa4d}; !- Roof Ceiling Construction Name
 
 OS:Construction,
   {99407b2e-49f5-4dd2-a138-e5f57ad89854}, !- Handle
@@ -6512,32 +3816,6 @@ OS:Material,
   0.7,                                    !- Solar Absorptance
   0.7;                                    !- Visible Absorptance
 
-OS:DefaultSurfaceConstructions,
-  {e18c1749-b591-41fb-9e64-177679114054}, !- Handle
-  Default Surface Constructions 5,        !- Name
-  {4ee71df9-85c1-4a24-9be8-bee433f9e015}, !- Floor Construction Name
-  {7ea68359-ad75-4d6c-8862-e2965b9ee3ab}, !- Wall Construction Name
-  {edd9ecd3-4290-4d56-b5a9-ef02bf102418}; !- Roof Ceiling Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {69098a8f-01d4-41f8-97e8-f3616bf95c30}, !- Handle
-  Default Surface Constructions 6,        !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Wall Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}; !- Roof Ceiling Construction Name
-
-OS:DefaultSubSurfaceConstructions,
-  {26c0a2ac-6869-41a8-85e0-493990988654}, !- Handle
-  Default Sub Surface Constructions 3,    !- Name
-  {7a0f32f0-ed41-4458-b35f-782d54c4cf3c}, !- Fixed Window Construction Name
-  {7a0f32f0-ed41-4458-b35f-782d54c4cf3c}, !- Operable Window Construction Name
-  {f16a7fb7-d40d-43c5-9ad7-3bfe84654a03}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Tubular Daylight Dome Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}; !- Tubular Daylight Diffuser Construction Name
-
 OS:Construction,
   {7a0f32f0-ed41-4458-b35f-782d54c4cf3c}, !- Handle
   ASHRAE 189.1-2009 ExtWindow ClimateZone 2, !- Name
@@ -6569,38 +3847,6 @@ OS:WindowMaterial:Glazing,
   1,                                      !- Dirt Correction Factor for Solar and Visible Transmittance
   No;                                     !- Solar Diffusing
 
-OS:DefaultSubSurfaceConstructions,
-  {31e1c75d-6ff4-480b-8189-458ca9a5f35c}, !- Handle
-  Default Sub Surface Constructions 4,    !- Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Fixed Window Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Operable Window Construction Name
-  {ffeb525e-fabf-4359-8b2f-bec6d1975f7c}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  ,                                       !- Tubular Daylight Dome Construction Name
-  ;                                       !- Tubular Daylight Diffuser Construction Name
-
-OS:DefaultConstructionSet,
-  {3506f604-9b28-4c01-8fc6-87fabe876a1b}, !- Handle
-  189.1-2009 - CZ3 - Office,              !- Name
-  {79cccbfe-3f49-4acb-bdf2-e7139171fa8f}, !- Default Exterior Surface Constructions Name
-  {d2c070d0-e055-4eab-91fe-70399799fd2c}, !- Default Interior Surface Constructions Name
-  {8e86a490-adb3-49ef-8ad5-5a0e28d39cf9}, !- Default Ground Contact Surface Constructions Name
-  {8e17c840-44c6-43f4-81f8-12f4bcac2369}, !- Default Exterior SubSurface Constructions Name
-  {2e3cc8bd-5113-4870-b568-af600af67faa}, !- Default Interior SubSurface Constructions Name
-  {ead91c2f-4359-42f5-b36e-9a36c9253598}, !- Interior Partition Construction Name
-  ,                                       !- Space Shading Construction Name
-  ,                                       !- Building Shading Construction Name
-  ;                                       !- Site Shading Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {79cccbfe-3f49-4acb-bdf2-e7139171fa8f}, !- Handle
-  Default Surface Constructions 7,        !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {dd95d8d1-cb40-4462-b3ef-6d971a9babc7}, !- Wall Construction Name
-  {6e592600-ac13-4db1-bf26-a5a95984aa4d}; !- Roof Ceiling Construction Name
-
 OS:Construction,
   {dd95d8d1-cb40-4462-b3ef-6d971a9babc7}, !- Handle
   ASHRAE 189.1-2009 ExtWall Mass ClimateZone 3, !- Name
@@ -6627,32 +3873,6 @@ OS:Material,
   0.9,                                    !- Thermal Absorptance
   0.5,                                    !- Solar Absorptance
   0.5;                                    !- Visible Absorptance
-
-OS:DefaultSurfaceConstructions,
-  {d2c070d0-e055-4eab-91fe-70399799fd2c}, !- Handle
-  Default Surface Constructions 8,        !- Name
-  {4ee71df9-85c1-4a24-9be8-bee433f9e015}, !- Floor Construction Name
-  {7ea68359-ad75-4d6c-8862-e2965b9ee3ab}, !- Wall Construction Name
-  {edd9ecd3-4290-4d56-b5a9-ef02bf102418}; !- Roof Ceiling Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {8e86a490-adb3-49ef-8ad5-5a0e28d39cf9}, !- Handle
-  Default Surface Constructions 9,        !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Wall Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}; !- Roof Ceiling Construction Name
-
-OS:DefaultSubSurfaceConstructions,
-  {8e17c840-44c6-43f4-81f8-12f4bcac2369}, !- Handle
-  Default Sub Surface Constructions 5,    !- Name
-  {253b4c5e-eec6-44ee-a66e-86e873e08a61}, !- Fixed Window Construction Name
-  {253b4c5e-eec6-44ee-a66e-86e873e08a61}, !- Operable Window Construction Name
-  {f16a7fb7-d40d-43c5-9ad7-3bfe84654a03}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Tubular Daylight Dome Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}; !- Tubular Daylight Diffuser Construction Name
 
 OS:Construction,
   {253b4c5e-eec6-44ee-a66e-86e873e08a61}, !- Handle
@@ -6685,38 +3905,6 @@ OS:WindowMaterial:Glazing,
   1,                                      !- Dirt Correction Factor for Solar and Visible Transmittance
   No;                                     !- Solar Diffusing
 
-OS:DefaultSubSurfaceConstructions,
-  {2e3cc8bd-5113-4870-b568-af600af67faa}, !- Handle
-  Default Sub Surface Constructions 6,    !- Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Fixed Window Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Operable Window Construction Name
-  {ffeb525e-fabf-4359-8b2f-bec6d1975f7c}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  ,                                       !- Tubular Daylight Dome Construction Name
-  ;                                       !- Tubular Daylight Diffuser Construction Name
-
-OS:DefaultConstructionSet,
-  {b7cdc63e-a919-41dd-86e1-dece88dfdb28}, !- Handle
-  189.1-2009 - CZ4 - Office,              !- Name
-  {3ef37f21-bbe3-4f3b-9b65-3ad9770f3a44}, !- Default Exterior Surface Constructions Name
-  {92813ed9-8be8-4db7-93eb-d9414bb5857c}, !- Default Interior Surface Constructions Name
-  {a1c91290-96c5-4ee4-988a-5b2845afb68b}, !- Default Ground Contact Surface Constructions Name
-  {8236d225-796d-412a-a2e2-1295101f741d}, !- Default Exterior SubSurface Constructions Name
-  {a9819d00-d437-4adf-b7bd-7824978b9e03}, !- Default Interior SubSurface Constructions Name
-  {ead91c2f-4359-42f5-b36e-9a36c9253598}, !- Interior Partition Construction Name
-  ,                                       !- Space Shading Construction Name
-  ,                                       !- Building Shading Construction Name
-  ;                                       !- Site Shading Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {3ef37f21-bbe3-4f3b-9b65-3ad9770f3a44}, !- Handle
-  Default Surface Constructions 10,       !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {b23633e3-75a0-470c-b30f-e321d99e7ed1}, !- Wall Construction Name
-  {6e592600-ac13-4db1-bf26-a5a95984aa4d}; !- Roof Ceiling Construction Name
-
 OS:Construction,
   {b23633e3-75a0-470c-b30f-e321d99e7ed1}, !- Handle
   ASHRAE 189.1-2009 ExtWall Mass ClimateZone 4, !- Name
@@ -6743,32 +3931,6 @@ OS:Material,
   0.9,                                    !- Thermal Absorptance
   0.5,                                    !- Solar Absorptance
   0.5;                                    !- Visible Absorptance
-
-OS:DefaultSurfaceConstructions,
-  {92813ed9-8be8-4db7-93eb-d9414bb5857c}, !- Handle
-  Default Surface Constructions 11,       !- Name
-  {4ee71df9-85c1-4a24-9be8-bee433f9e015}, !- Floor Construction Name
-  {7ea68359-ad75-4d6c-8862-e2965b9ee3ab}, !- Wall Construction Name
-  {edd9ecd3-4290-4d56-b5a9-ef02bf102418}; !- Roof Ceiling Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {a1c91290-96c5-4ee4-988a-5b2845afb68b}, !- Handle
-  Default Surface Constructions 12,       !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Wall Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}; !- Roof Ceiling Construction Name
-
-OS:DefaultSubSurfaceConstructions,
-  {8236d225-796d-412a-a2e2-1295101f741d}, !- Handle
-  Default Sub Surface Constructions 7,    !- Name
-  {a19abee3-5e27-4244-9552-a3961f6ec2b6}, !- Fixed Window Construction Name
-  {a19abee3-5e27-4244-9552-a3961f6ec2b6}, !- Operable Window Construction Name
-  {f16a7fb7-d40d-43c5-9ad7-3bfe84654a03}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Tubular Daylight Dome Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}; !- Tubular Daylight Diffuser Construction Name
 
 OS:Construction,
   {a19abee3-5e27-4244-9552-a3961f6ec2b6}, !- Handle
@@ -6801,38 +3963,6 @@ OS:WindowMaterial:Glazing,
   1,                                      !- Dirt Correction Factor for Solar and Visible Transmittance
   No;                                     !- Solar Diffusing
 
-OS:DefaultSubSurfaceConstructions,
-  {a9819d00-d437-4adf-b7bd-7824978b9e03}, !- Handle
-  Default Sub Surface Constructions 8,    !- Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Fixed Window Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Operable Window Construction Name
-  {ffeb525e-fabf-4359-8b2f-bec6d1975f7c}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  ,                                       !- Tubular Daylight Dome Construction Name
-  ;                                       !- Tubular Daylight Diffuser Construction Name
-
-OS:DefaultConstructionSet,
-  {58749418-1c83-496b-94e6-80aa0fd3ac39}, !- Handle
-  189.1-2009 - CZ5 - Office,              !- Name
-  {f6881ecb-7aaf-431a-b1d2-61de79238f70}, !- Default Exterior Surface Constructions Name
-  {d97abec2-033d-43ce-a763-4ed6937bae4d}, !- Default Interior Surface Constructions Name
-  {d684c8db-7bf4-4966-b9eb-ea0c2afdf86b}, !- Default Ground Contact Surface Constructions Name
-  {bb191ec6-d6ab-407d-9fb2-31dc2ae3bb75}, !- Default Exterior SubSurface Constructions Name
-  {b6d85e89-1972-4d08-8dd6-1ad51c17f701}, !- Default Interior SubSurface Constructions Name
-  {ead91c2f-4359-42f5-b36e-9a36c9253598}, !- Interior Partition Construction Name
-  ,                                       !- Space Shading Construction Name
-  ,                                       !- Building Shading Construction Name
-  ;                                       !- Site Shading Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {f6881ecb-7aaf-431a-b1d2-61de79238f70}, !- Handle
-  Default Surface Constructions 13,       !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {69871c9e-7438-4e91-92bd-66fabb7f9850}, !- Wall Construction Name
-  {6e592600-ac13-4db1-bf26-a5a95984aa4d}; !- Roof Ceiling Construction Name
-
 OS:Construction,
   {69871c9e-7438-4e91-92bd-66fabb7f9850}, !- Handle
   ASHRAE 189.1-2009 ExtWall Mass ClimateZone 5, !- Name
@@ -6859,64 +3989,6 @@ OS:Material,
   0.9,                                    !- Thermal Absorptance
   0.5,                                    !- Solar Absorptance
   0.5;                                    !- Visible Absorptance
-
-OS:DefaultSurfaceConstructions,
-  {d97abec2-033d-43ce-a763-4ed6937bae4d}, !- Handle
-  Default Surface Constructions 14,       !- Name
-  {4ee71df9-85c1-4a24-9be8-bee433f9e015}, !- Floor Construction Name
-  {7ea68359-ad75-4d6c-8862-e2965b9ee3ab}, !- Wall Construction Name
-  {edd9ecd3-4290-4d56-b5a9-ef02bf102418}; !- Roof Ceiling Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {d684c8db-7bf4-4966-b9eb-ea0c2afdf86b}, !- Handle
-  Default Surface Constructions 15,       !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Wall Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}; !- Roof Ceiling Construction Name
-
-OS:DefaultSubSurfaceConstructions,
-  {bb191ec6-d6ab-407d-9fb2-31dc2ae3bb75}, !- Handle
-  Default Sub Surface Constructions 9,    !- Name
-  {a19abee3-5e27-4244-9552-a3961f6ec2b6}, !- Fixed Window Construction Name
-  {a19abee3-5e27-4244-9552-a3961f6ec2b6}, !- Operable Window Construction Name
-  {f16a7fb7-d40d-43c5-9ad7-3bfe84654a03}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Tubular Daylight Dome Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}; !- Tubular Daylight Diffuser Construction Name
-
-OS:DefaultSubSurfaceConstructions,
-  {b6d85e89-1972-4d08-8dd6-1ad51c17f701}, !- Handle
-  Default Sub Surface Constructions 10,   !- Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Fixed Window Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Operable Window Construction Name
-  {ffeb525e-fabf-4359-8b2f-bec6d1975f7c}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  ,                                       !- Tubular Daylight Dome Construction Name
-  ;                                       !- Tubular Daylight Diffuser Construction Name
-
-OS:DefaultConstructionSet,
-  {7fbfa4b5-c598-498c-9e7e-cc1d23784e59}, !- Handle
-  189.1-2009 - CZ6 - Office,              !- Name
-  {f4c2eff4-616f-4e59-a975-63e8f99df809}, !- Default Exterior Surface Constructions Name
-  {d61c2378-904c-4c76-bac0-dbd9f6c49c7c}, !- Default Interior Surface Constructions Name
-  {d64e486a-afe2-4d33-9add-91d98c40c1d7}, !- Default Ground Contact Surface Constructions Name
-  {5897f70f-27c7-4970-9e2c-db9bebccea4e}, !- Default Exterior SubSurface Constructions Name
-  {ec05d2f3-b3ec-4dfb-820b-5fffaeb8776d}, !- Default Interior SubSurface Constructions Name
-  {ead91c2f-4359-42f5-b36e-9a36c9253598}, !- Interior Partition Construction Name
-  ,                                       !- Space Shading Construction Name
-  ,                                       !- Building Shading Construction Name
-  ;                                       !- Site Shading Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {f4c2eff4-616f-4e59-a975-63e8f99df809}, !- Handle
-  Default Surface Constructions 16,       !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {73014c8f-a248-42b8-886b-3d7b760f079b}, !- Wall Construction Name
-  {e58f4a9d-2329-4c5d-8385-2f9db5c419bf}; !- Roof Ceiling Construction Name
 
 OS:Construction,
   {73014c8f-a248-42b8-886b-3d7b760f079b}, !- Handle
@@ -6983,32 +4055,6 @@ OS:Material,
   0.7,                                    !- Solar Absorptance
   0.7;                                    !- Visible Absorptance
 
-OS:DefaultSurfaceConstructions,
-  {d61c2378-904c-4c76-bac0-dbd9f6c49c7c}, !- Handle
-  Default Surface Constructions 17,       !- Name
-  {4ee71df9-85c1-4a24-9be8-bee433f9e015}, !- Floor Construction Name
-  {7ea68359-ad75-4d6c-8862-e2965b9ee3ab}, !- Wall Construction Name
-  {edd9ecd3-4290-4d56-b5a9-ef02bf102418}; !- Roof Ceiling Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {d64e486a-afe2-4d33-9add-91d98c40c1d7}, !- Handle
-  Default Surface Constructions 18,       !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Wall Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}; !- Roof Ceiling Construction Name
-
-OS:DefaultSubSurfaceConstructions,
-  {5897f70f-27c7-4970-9e2c-db9bebccea4e}, !- Handle
-  Default Sub Surface Constructions 11,   !- Name
-  {b343d191-cd60-41c8-9583-fcdf8aef2341}, !- Fixed Window Construction Name
-  {b343d191-cd60-41c8-9583-fcdf8aef2341}, !- Operable Window Construction Name
-  {f16a7fb7-d40d-43c5-9ad7-3bfe84654a03}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Tubular Daylight Dome Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}; !- Tubular Daylight Diffuser Construction Name
-
 OS:Construction,
   {b343d191-cd60-41c8-9583-fcdf8aef2341}, !- Handle
   ASHRAE 189.1-2009 ExtWindow ClimateZone 6, !- Name
@@ -7039,38 +4085,6 @@ OS:WindowMaterial:Glazing,
   0.0133,                                 !- Conductivity {W/m-K}
   1,                                      !- Dirt Correction Factor for Solar and Visible Transmittance
   No;                                     !- Solar Diffusing
-
-OS:DefaultSubSurfaceConstructions,
-  {ec05d2f3-b3ec-4dfb-820b-5fffaeb8776d}, !- Handle
-  Default Sub Surface Constructions 12,   !- Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Fixed Window Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Operable Window Construction Name
-  {ffeb525e-fabf-4359-8b2f-bec6d1975f7c}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  ,                                       !- Tubular Daylight Dome Construction Name
-  ;                                       !- Tubular Daylight Diffuser Construction Name
-
-OS:DefaultConstructionSet,
-  {1cff5d19-5572-4e19-88b4-346c54265f57}, !- Handle
-  189.1-2009 - CZ7-8 - Office,            !- Name
-  {6e044d24-cbba-456f-af36-8b86f1508f50}, !- Default Exterior Surface Constructions Name
-  {e3c760b2-11c7-4984-bdaf-ed3f8f1fbab8}, !- Default Interior Surface Constructions Name
-  {5a5b254f-3a7d-49cd-8c7b-df8e0f5efded}, !- Default Ground Contact Surface Constructions Name
-  {c766fd3a-9093-42fa-9514-2c1fa80247f2}, !- Default Exterior SubSurface Constructions Name
-  {af87ce18-ae87-4260-a697-cd25f4095498}, !- Default Interior SubSurface Constructions Name
-  {ead91c2f-4359-42f5-b36e-9a36c9253598}, !- Interior Partition Construction Name
-  ,                                       !- Space Shading Construction Name
-  ,                                       !- Building Shading Construction Name
-  ;                                       !- Site Shading Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {6e044d24-cbba-456f-af36-8b86f1508f50}, !- Handle
-  Default Surface Constructions 19,       !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {d28d8415-2d7a-4256-be8e-91b455fe8889}, !- Wall Construction Name
-  {c6bbd742-fc9f-439b-94f4-e8038f26f5bd}; !- Roof Ceiling Construction Name
 
 OS:Construction,
   {d28d8415-2d7a-4256-be8e-91b455fe8889}, !- Handle
@@ -7125,32 +4139,6 @@ OS:Material,
   0.7,                                    !- Solar Absorptance
   0.7;                                    !- Visible Absorptance
 
-OS:DefaultSurfaceConstructions,
-  {e3c760b2-11c7-4984-bdaf-ed3f8f1fbab8}, !- Handle
-  Default Surface Constructions 20,       !- Name
-  {4ee71df9-85c1-4a24-9be8-bee433f9e015}, !- Floor Construction Name
-  {7ea68359-ad75-4d6c-8862-e2965b9ee3ab}, !- Wall Construction Name
-  {edd9ecd3-4290-4d56-b5a9-ef02bf102418}; !- Roof Ceiling Construction Name
-
-OS:DefaultSurfaceConstructions,
-  {5a5b254f-3a7d-49cd-8c7b-df8e0f5efded}, !- Handle
-  Default Surface Constructions 21,       !- Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Floor Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}, !- Wall Construction Name
-  {78a5e5c5-806e-400a-a800-196f73e1d063}; !- Roof Ceiling Construction Name
-
-OS:DefaultSubSurfaceConstructions,
-  {c766fd3a-9093-42fa-9514-2c1fa80247f2}, !- Handle
-  Default Sub Surface Constructions 13,   !- Name
-  {b7889a36-262c-4dbe-b8ee-96206687aa1b}, !- Fixed Window Construction Name
-  {b7889a36-262c-4dbe-b8ee-96206687aa1b}, !- Operable Window Construction Name
-  {f16a7fb7-d40d-43c5-9ad7-3bfe84654a03}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Tubular Daylight Dome Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}; !- Tubular Daylight Diffuser Construction Name
-
 OS:Construction,
   {b7889a36-262c-4dbe-b8ee-96206687aa1b}, !- Handle
   ASHRAE 189.1-2009 ExtWindow ClimateZone 7-8, !- Name
@@ -7181,18 +4169,6 @@ OS:WindowMaterial:Glazing,
   0.0089,                                 !- Conductivity {W/m-K}
   1,                                      !- Dirt Correction Factor for Solar and Visible Transmittance
   No;                                     !- Solar Diffusing
-
-OS:DefaultSubSurfaceConstructions,
-  {af87ce18-ae87-4260-a697-cd25f4095498}, !- Handle
-  Default Sub Surface Constructions 14,   !- Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Fixed Window Construction Name
-  {ae4fa780-ed05-42e8-925d-8cfdef96ee27}, !- Operable Window Construction Name
-  {ffeb525e-fabf-4359-8b2f-bec6d1975f7c}, !- Door Construction Name
-  ,                                       !- Glass Door Construction Name
-  ,                                       !- Overhead Door Construction Name
-  ,                                       !- Skylight Construction Name
-  ,                                       !- Tubular Daylight Dome Construction Name
-  ;                                       !- Tubular Daylight Diffuser Construction Name
 
 OS:Material:AirWall,
   {8ea9f6e6-0bb1-424a-a9d5-8fb8da2c8afe}, !- Handle
@@ -8654,50 +5630,12 @@ OS:ThermostatSetpoint:DualSetpoint,
   {2afd91c0-e092-45e4-8fd9-f7547eaaaf0a}, !- Heating Setpoint Temperature Schedule Name
   {ff094589-1012-4888-8ee6-d05468d2c388}; !- Cooling Setpoint Temperature Schedule Name
 
-OS:SpaceType,
-  {3edba7e5-b8e0-4555-9448-149ed9de09f8}, !- Handle
-  DOE Ref Pre-1980 - Retail - Point_of_Sale, !- Name
-  ,                                       !- Default Construction Set Name
-  {7052cc11-076e-4fef-8d7c-41bbf28acd90}, !- Default Schedule Set Name
-  {78affdad-6d01-46f0-bb53-2daf00e5309e}, !- Group Rendering Name
-  {4617460a-188e-422d-9565-34ce766ed611}, !- Design Specification Outdoor Air Object Name
-  Retail,                                 !- Standards Building Type
-  Point_of_Sale;                          !- Standards Space Type
-
 OS:Rendering:Color,
   {78affdad-6d01-46f0-bb53-2daf00e5309e}, !- Handle
   Rendering Color 64,                     !- Name
   171,                                    !- Rendering Red Value
   222,                                    !- Rendering Green Value
   78;                                     !- Rendering Blue Value
-
-OS:DefaultScheduleSet,
-  {7052cc11-076e-4fef-8d7c-41bbf28acd90}, !- Handle
-  DOE Ref Pre-1980 - Retail - Point_of_Sale Schedule Set, !- Name
-  ,                                       !- Hours of Operation Schedule Name
-  {3f2c281b-2880-437c-9ba2-bc3dedff516c}, !- Number of People Schedule Name
-  {cdc340a8-7617-420e-b7d9-f0d518d9bdf3}, !- People Activity Level Schedule Name
-  {519f1393-154f-48a3-abf3-b4259184f75a}, !- Lighting Schedule Name
-  {afb7c502-efcf-4588-8f7f-d170513af535}, !- Electric Equipment Schedule Name
-  ,                                       !- Gas Equipment Schedule Name
-  ,                                       !- Hot Water Equipment Schedule Name
-  {9b632351-6f29-44df-8db8-ea74fdb73fd9}, !- Infiltration Schedule Name
-  ,                                       !- Steam Equipment Schedule Name
-  ;                                       !- Other Equipment Schedule Name
-
-OS:Lights:Definition,
-  {1ca5494a-d8b0-4d2c-a9af-93736f503d6d}, !- Handle
-  DOE Ref Pre-1980 - Retail - Point_of_Sale Lights Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Lighting Level {W}
-  54.250108500217,                        !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:Lights,
-  {3d676fb3-126c-4d7e-b26b-ec0ccd91caf8}, !- Handle
-  DOE Ref Pre-1980 - Retail - Point_of_Sale Lights, !- Name
-  {1ca5494a-d8b0-4d2c-a9af-93736f503d6d}, !- Lights Definition Name
-  {3edba7e5-b8e0-4555-9448-149ed9de09f8}; !- Space or SpaceType Name
 
 OS:DesignSpecification:OutdoorAir,
   {4617460a-188e-422d-9565-34ce766ed611}, !- Handle
@@ -8708,50 +5646,6 @@ OS:DesignSpecification:OutdoorAir,
   ,                                       !- Outdoor Air Flow Rate {m3/s}
   ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
-
-OS:People:Definition,
-  {6dab1f81-c99f-42c6-90c2-1f234f70a0bb}, !- Handle
-  DOE Ref Pre-1980 - Retail - Point_of_Sale People Definition, !- Name
-  People/Area,                            !- Number of People Calculation Method
-  ,                                       !- Number of People {people}
-  0.161458656250646,                      !- People per Space Floor Area {person/m2}
-  ,                                       !- Space Floor Area per Person {m2/person}
-  0.3;                                    !- Fraction Radiant
-
-OS:People,
-  {70d37f47-23f1-4121-856b-22ad5bd8e772}, !- Handle
-  DOE Ref Pre-1980 - Retail - Point_of_Sale People, !- Name
-  {6dab1f81-c99f-42c6-90c2-1f234f70a0bb}, !- People Definition Name
-  {3edba7e5-b8e0-4555-9448-149ed9de09f8}; !- Space or SpaceType Name
-
-OS:SpaceInfiltration:DesignFlowRate,
-  {20b429aa-162d-4fba-84b1-0cbe84205167}, !- Handle
-  DOE Ref Pre-1980 - Retail - Point_of_Sale Infiltration, !- Name
-  {3edba7e5-b8e0-4555-9448-149ed9de09f8}, !- Space or SpaceType Name
-  ,                                       !- Schedule Name
-  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
-  ,                                       !- Design Flow Rate {m3/s}
-  ,                                       !- Flow per Space Floor Area {m3/s-m2}
-  0.001133856,                            !- Flow per Exterior Surface Area {m3/s-m2}
-  ,                                       !- Air Changes per Hour {1/hr}
-  ,                                       !- Constant Term Coefficient
-  ,                                       !- Temperature Term Coefficient
-  ,                                       !- Velocity Term Coefficient
-  ;                                       !- Velocity Squared Term Coefficient
-
-OS:ElectricEquipment:Definition,
-  {2b05c3c5-f7ce-4490-8c9e-fa6010c1ca83}, !- Handle
-  DOE Ref Pre-1980 - Retail - Point_of_Sale Electric Equipment Definition, !- Name
-  Watts/Area,                             !- Design Level Calculation Method
-  ,                                       !- Design Level {W}
-  21.5278208334194,                       !- Watts per Space Floor Area {W/m2}
-  ;                                       !- Watts per Person {W/person}
-
-OS:ElectricEquipment,
-  {e8a74139-8f76-47c6-8670-efe94acd412f}, !- Handle
-  DOE Ref Pre-1980 - Retail - Point_of_Sale Electric Equipment, !- Name
-  {2b05c3c5-f7ce-4490-8c9e-fa6010c1ca83}, !- Electric Equipment Definition Name
-  {3edba7e5-b8e0-4555-9448-149ed9de09f8}; !- Space or SpaceType Name
 
 OS:ThermostatSetpoint:DualSetpoint,
   {b8017bdf-2f91-481d-89ae-ba46de9d6162}, !- Handle


### PR DESCRIPTION
Fix #177.

### measure.rb
1. Updates SQL queries for new names
2. Calculates lighting EFLH using EnergyMeters (kWh / kW) instead of Lighting Summary

### gas_electric_mark_load.osm
1. Purge unused objects
2. Adds GasEquipment for ZoneReport to avoid test failures