### PR TITLE
fix openstudio results rendering

### DIFF
--- a/lib/measures/openstudio_results/README.md
+++ b/lib/measures/openstudio_results/README.md
@@ -220,7 +220,7 @@ This argument does not effect HTML file, instead it makes data from individal ce
 **Model Dependent:** false
 
 ### HTML Dependencies
-Location of HTML dependencies.
+Location of HTML dependencies. Local is useful for working offline.
 **Name:** html_dependencies,
 **Type:** Choice,
 **Units:** ,

--- a/lib/measures/openstudio_results/README.md
+++ b/lib/measures/openstudio_results/README.md
@@ -219,6 +219,14 @@ This argument does not effect HTML file, instead it makes data from individal ce
 **Required:** true,
 **Model Dependent:** false
 
+### HTML Dependencies
+Location of HTML dependencies.
+**Name:** html_dependencies,
+**Type:** Choice,
+**Units:** ,
+**Required:** true,
+**Model Dependent:** false
+
 
 
 

--- a/lib/measures/openstudio_results/measure.rb
+++ b/lib/measures/openstudio_results/measure.rb
@@ -131,11 +131,11 @@ class OpenStudioResults < OpenStudio::Measure::ReportingMeasure
 
     # location of html dependencies, revit systems analysis uses local files
     html_dependencies_choices = OpenStudio::StringVector.new
-    html_dependencies_choices << 'Remote'
     html_dependencies_choices << 'Local'
+    html_dependencies_choices << 'Remote'
     html_dependencies = OpenStudio::Measure::OSArgument::makeChoiceArgument('html_dependencies', html_dependencies_choices, true)
     html_dependencies.setDisplayName('HTML Dependencies')
-    html_dependencies.setDescription('Location of HTML dependencies.')
+    html_dependencies.setDescription('Location of HTML dependencies. Local is useful for working offline.')
     html_dependencies.setDefaultValue('Remote')
     args << html_dependencies
 

--- a/lib/measures/openstudio_results/measure.rb
+++ b/lib/measures/openstudio_results/measure.rb
@@ -129,6 +129,16 @@ class OpenStudioResults < OpenStudio::Measure::ReportingMeasure
     energyplus_reports.setDefaultValue(false)
     args << energyplus_reports
 
+    # location of html dependencies, revit systems analysis uses local files
+    html_dependencies_choices = OpenStudio::StringVector.new
+    html_dependencies_choices << 'Remote'
+    html_dependencies_choices << 'Local'
+    html_dependencies = OpenStudio::Measure::OSArgument::makeChoiceArgument('html_dependencies', html_dependencies_choices, true)
+    html_dependencies.setDisplayName('HTML Dependencies')
+    html_dependencies.setDescription('Location of HTML dependencies.')
+    html_dependencies.setDefaultValue('Remote')
+    args << html_dependencies
+
     args
   end
 
@@ -219,6 +229,7 @@ class OpenStudioResults < OpenStudio::Measure::ReportingMeasure
     args = runner.getArgumentValues(arguments, user_arguments)
     args = Hash[args.collect{ |k, v| [k.to_s, v] }]
     energyplus_reports = runner.getBoolArgumentValue('energyplus_reports', user_arguments)
+    @html_dependencies = runner.getStringArgumentValue('html_dependencies', user_arguments)
     unless args
       return false
     end

--- a/lib/measures/openstudio_results/measure.xml
+++ b/lib/measures/openstudio_results/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>openstudio_results</name>
   <uid>a25386cd-60e4-46bc-8b11-c755f379d916</uid>
-  <version_id>a70480c9-7dfa-42f7-9632-93f96baafc66</version_id>
-  <version_modified>2024-11-16T23:54:10Z</version_modified>
+  <version_id>f9dfd818-9855-406f-a577-c3e6a57db4e4</version_id>
+  <version_modified>2025-04-10T19:56:40Z</version_modified>
   <xml_checksum>557BF06F</xml_checksum>
   <class_name>OpenStudioResults</class_name>
   <display_name>OpenStudio Results</display_name>
@@ -467,6 +467,25 @@
         </choice>
       </choices>
     </argument>
+    <argument>
+      <name>html_dependencies</name>
+      <display_name>HTML Dependencies</display_name>
+      <description>Location of HTML dependencies.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>Remote</default_value>
+      <choices>
+        <choice>
+          <value>Remote</value>
+          <display_name>Remote</display_name>
+        </choice>
+        <choice>
+          <value>Local</value>
+          <display_name>Local</display_name>
+        </choice>
+      </choices>
+    </argument>
   </arguments>
   <outputs>
     <output>
@@ -629,7 +648,7 @@
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>E0389149</checksum>
+      <checksum>200A0F7F</checksum>
     </file>
     <file>
       <filename>README.md.erb</filename>
@@ -646,7 +665,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>2D427F94</checksum>
+      <checksum>4352F61D</checksum>
     </file>
     <file>
       <filename>Siz.AirConditionerVariableRefrigerantFlow.rb</filename>
@@ -1462,7 +1481,7 @@
       <filename>report.html.erb</filename>
       <filetype>erb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>3151B6DF</checksum>
+      <checksum>9D65F63F</checksum>
     </file>
     <file>
       <filename>1004_SmallHotel_a.osm</filename>

--- a/lib/measures/openstudio_results/measure.xml
+++ b/lib/measures/openstudio_results/measure.xml
@@ -470,19 +470,19 @@
     <argument>
       <name>html_dependencies</name>
       <display_name>HTML Dependencies</display_name>
-      <description>Location of HTML dependencies.</description>
+      <description>Location of HTML dependencies. Local is useful for working offline.</description>
       <type>Choice</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>Remote</default_value>
       <choices>
         <choice>
-          <value>Remote</value>
-          <display_name>Remote</display_name>
-        </choice>
-        <choice>
           <value>Local</value>
           <display_name>Local</display_name>
+        </choice>
+        <choice>
+          <value>Remote</value>
+          <display_name>Remote</display_name>
         </choice>
       </choices>
     </argument>
@@ -648,7 +648,7 @@
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>200A0F7F</checksum>
+      <checksum>03CD4A32</checksum>
     </file>
     <file>
       <filename>README.md.erb</filename>
@@ -665,7 +665,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>4352F61D</checksum>
+      <checksum>02BE0BDF</checksum>
     </file>
     <file>
       <filename>Siz.AirConditionerVariableRefrigerantFlow.rb</filename>
@@ -1481,7 +1481,7 @@
       <filename>report.html.erb</filename>
       <filetype>erb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>9D65F63F</checksum>
+      <checksum>6E05F5AE</checksum>
     </file>
     <file>
       <filename>1004_SmallHotel_a.osm</filename>

--- a/lib/measures/openstudio_results/resources/report.html.erb
+++ b/lib/measures/openstudio_results/resources/report.html.erb
@@ -35,18 +35,18 @@
   <title>OpenStudio Results</title>
 
   <% case @html_dependencies
-     when 'Remote' %>
-    <link href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
-    <script type="text/javascript" src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/d3/3.4.8/d3.min.js"></script>
-    <script type="text/javascript" src="http://dimplejs.org/dist/dimple.v2.1.2.min.js"></script>
-  <% when 'Local' %>
-    <link href="<%= File.join(resources_path, "bootstrap.min.css") %>" rel="stylesheet">
-    <script type="text/javascript" src="<%= File.join(resources_path, "jquery.min.js") %>"></script>
-    <script type="text/javascript" src="<%= File.join(resources_path, "bootstrap.min.js") %>"></script>
-    <script type="text/javascript" src="<%= File.join(resources_path, "d3.min.js") %>"></script>
-    <script type="text/javascript" src="<%= File.join(resources_path, "dimple.v2.1.2.min.js") %>"></script>
+     when 'Local' %>
+      <link href="<%= File.join(resources_path, "bootstrap.min.css") %>" rel="stylesheet">
+      <script type="text/javascript" src="<%= File.join(resources_path, "jquery.min.js") %>"></script>
+      <script type="text/javascript" src="<%= File.join(resources_path, "bootstrap.min.js") %>"></script>
+      <script type="text/javascript" src="<%= File.join(resources_path, "d3.min.js") %>"></script>
+      <script type="text/javascript" src="<%= File.join(resources_path, "dimple.v2.1.2.min.js") %>"></script>
+  <% when 'Remote' %>
+      <link href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+      <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+      <script type="text/javascript" src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+      <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/d3/3.4.8/d3.min.js"></script>
+      <script type="text/javascript" src="http://dimplejs.org/dist/dimple.v2.1.2.min.js"></script>
   <% end %>
 
   <style>

--- a/lib/measures/openstudio_results/resources/report.html.erb
+++ b/lib/measures/openstudio_results/resources/report.html.erb
@@ -33,12 +33,22 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>OpenStudio Results</title>
-  <link href="<%= File.join(resources_path, "bootstrap.min.css") %>" rel="stylesheet">
 
-  <script type="text/javascript" src="<%= File.join(resources_path, "jquery.min.js") %>"></script>
-  <script type="text/javascript" src="<%= File.join(resources_path, "bootstrap.min.js") %>"></script>
-  <script type="text/javascript" src="<%= File.join(resources_path, "d3.min.js") %>"></script>
-  <script type="text/javascript" src="<%= File.join(resources_path, "dimple.v2.1.2.min.js") %>"></script>
+  <% case @html_dependencies
+     when 'Remote' %>
+    <link href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+    <script type="text/javascript" src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/d3/3.4.8/d3.min.js"></script>
+    <script type="text/javascript" src="http://dimplejs.org/dist/dimple.v2.1.2.min.js"></script>
+  <% when 'Local' %>
+    <link href="<%= File.join(resources_path, "bootstrap.min.css") %>" rel="stylesheet">
+    <script type="text/javascript" src="<%= File.join(resources_path, "jquery.min.js") %>"></script>
+    <script type="text/javascript" src="<%= File.join(resources_path, "bootstrap.min.js") %>"></script>
+    <script type="text/javascript" src="<%= File.join(resources_path, "d3.min.js") %>"></script>
+    <script type="text/javascript" src="<%= File.join(resources_path, "dimple.v2.1.2.min.js") %>"></script>
+  <% end %>
+
   <style>
       body {
           position: relative;


### PR DESCRIPTION
Fix #193. Adds an argument for `HTML Dependencies`, which controls where the files are fetched from. In addition to fixing the rendering issue, the `Local` choice is useful for working offline.

**Remote (offline)**

![image](https://github.com/user-attachments/assets/302d0190-a048-407d-905d-99af5fb98e4d)

**Remote (online)**

![image](https://github.com/user-attachments/assets/38cb881b-8a3e-4a11-968a-d1a964f727d8)

**Local (offline)**

![image](https://github.com/user-attachments/assets/44da3801-5d0f-4238-8a73-20b24c2e1b88)

**Local (online)**

![image](https://github.com/user-attachments/assets/e7f26a54-c802-4e44-996b-6633a7b40fb8)
