### PR TITLE
fix compressorMotorEfficiency in openstudio_results

### DIFF
--- a/lib/measures/openstudio_results/resources/Siz.ChillerElectricEIR.rb
+++ b/lib/measures/openstudio_results/resources/Siz.ChillerElectricEIR.rb
@@ -58,8 +58,8 @@ class OpenStudio::Model::ChillerElectricEIR
   def performanceCharacteristics
     effs = []
     effs << [referenceCOP, 'Reference COP']
-    # changed in EnergyPlus 8.2.0
-    if Gem::Version.new(OpenStudio.openStudioVersion) < Gem::Version.new('1.5.4')
+    # changed in OpenStudio 2.9.1
+    if Gem::Version.new(OpenStudio.openStudioVersion) < Gem::Version.new('2.9.1')
       effs << [compressorMotorEfficiency, 'Compressor Motor Efficiency']
     else
       effs << [fractionofCompressorElectricConsumptionRejectedbyCondenser, 'Fraction of Compressor Electric Consumption Rejected by Condenser']

--- a/lib/measures/openstudio_results/resources/Siz.ChillerElectricEIR.rb
+++ b/lib/measures/openstudio_results/resources/Siz.ChillerElectricEIR.rb
@@ -58,11 +58,11 @@ class OpenStudio::Model::ChillerElectricEIR
   def performanceCharacteristics
     effs = []
     effs << [referenceCOP, 'Reference COP']
-    # check os version
-    if Gem::Version.new(OpenStudio.openStudioVersion) > Gem::Version.new('2.9.1')
-      effs << [fractionofCompressorElectricConsumptionRejectedbyCondenser, 'Fraction of Compressor Electric Consumption Rejected by Condenser']
+    # changed in EnergyPlus 8.2.0
+    if Gem::Version.new(OpenStudio.openStudioVersion) < Gem::Version.new('1.5.4')
+      effs << [compressorMotorEfficiency, 'Compressor Motor Efficiency']
     else
-      effs << [compressorMotorEfficiency, 'Compressor Motor Fraction of Compressor Electric Consumption Rejected by Condenser']
+      effs << [fractionofCompressorElectricPowerRejectedbyCondenser, 'Fraction of Compressor Electric Power Rejected by Condenser']      
     end
     return effs
   end

--- a/lib/measures/openstudio_results/resources/Siz.ChillerElectricEIR.rb
+++ b/lib/measures/openstudio_results/resources/Siz.ChillerElectricEIR.rb
@@ -62,7 +62,7 @@ class OpenStudio::Model::ChillerElectricEIR
     if Gem::Version.new(OpenStudio.openStudioVersion) < Gem::Version.new('1.5.4')
       effs << [compressorMotorEfficiency, 'Compressor Motor Efficiency']
     else
-      effs << [compressorMotorEfficiency, 'Compressor Motor Fraction of Compressor Electric Consumption Rejected by Condenser']
+      effs << [fractionofCompressorElectricConsumptionRejectedbyCondenser, 'Fraction of Compressor Electric Power Rejected by Condenser']
     end
     return effs
   end

--- a/lib/measures/openstudio_results/resources/Siz.ChillerElectricEIR.rb
+++ b/lib/measures/openstudio_results/resources/Siz.ChillerElectricEIR.rb
@@ -62,7 +62,7 @@ class OpenStudio::Model::ChillerElectricEIR
     if Gem::Version.new(OpenStudio.openStudioVersion) < Gem::Version.new('1.5.4')
       effs << [compressorMotorEfficiency, 'Compressor Motor Efficiency']
     else
-      effs << [fractionofCompressorElectricConsumptionRejectedbyCondenser, 'Fraction of Compressor Electric Power Rejected by Condenser']
+      effs << [fractionofCompressorElectricConsumptionRejectedbyCondenser, 'Fraction of Compressor Electric Consumption Rejected by Condenser']
     end
     return effs
   end

--- a/lib/measures/openstudio_results/resources/Siz.ChillerElectricEIR.rb
+++ b/lib/measures/openstudio_results/resources/Siz.ChillerElectricEIR.rb
@@ -62,7 +62,7 @@ class OpenStudio::Model::ChillerElectricEIR
     if Gem::Version.new(OpenStudio.openStudioVersion) < Gem::Version.new('1.5.4')
       effs << [compressorMotorEfficiency, 'Compressor Motor Efficiency']
     else
-      effs << [fractionofCompressorElectricPowerRejectedbyCondenser, 'Fraction of Compressor Electric Power Rejected by Condenser']      
+      effs << [compressorMotorEfficiency, 'Compressor Motor Fraction of Compressor Electric Consumption Rejected by Condenser']
     end
     return effs
   end

--- a/lib/measures/openstudio_results/resources/Siz.ChillerHeaterPerformanceElectricEIR.rb
+++ b/lib/measures/openstudio_results/resources/Siz.ChillerHeaterPerformanceElectricEIR.rb
@@ -41,12 +41,7 @@ class OpenStudio::Model::ChillerHeaterPerformanceElectricEIR
   def performanceCharacteristics
     effs = []
     effs << [referenceCoolingModeCOP, 'Reference Cooling Mode COP']
-    # check os version
-    if Gem::Version.new(OpenStudio.openStudioVersion) > Gem::Version.new('2.9.1')
-      effs << [fractionofCompressorElectricConsumptionRejectedbyCondenser, 'Fraction of Compressor Electric Consumption Rejected by Condenser']
-    else
-      effs << [compressorMotorEfficiency, 'Compressor Motor Fraction of Compressor Electric Consumption Rejected by Condenser']
-    end
+    effs << [compressorMotorEfficiency, 'Compressor Motor Efficiency']
     return effs
   end
 end


### PR DESCRIPTION
Fix #22. The ChillerElectricEIR object `compressorMotorEfficiency` field was changed in OS 2.9.1, which was a long time after it was changed in EP.